### PR TITLE
Update repo address

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,9 @@
 build
-.pybuild 
+.pybuild
 *.pyc
 debian/.debhelper/
 debian/files
 debian/xyz.isantop.repoman*
 debian/com.github*
+debian/repoman*
 *~

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ sudo apt install repoman
 Additionally, you can use **git**:
 
 ```bash
-git clone https://github.com/isantop/repoman.git
+git clone https://github.com/pop-os/repoman.git
 cd repoman
 sudo python3 setup.py install
 ```

--- a/README.md
+++ b/README.md
@@ -12,7 +12,6 @@ Repoman is based on [PPAExtender](https://github.com/mirkobrombin/PPAExtender)
 ## Requirements
 - python3
 - libgtk-3-dev
-- libgranite-dev
 - software-properties-common
 
 ## Installation


### PR DESCRIPTION
I think git clone instructions for the Pop!_OS version of repoman should link to the Pop!_OS version of the repo github.com/pop-os/repoman