### PR TITLE
Theming fixes

### DIFF
--- a/data/style.css
+++ b/data/style.css
@@ -36,3 +36,7 @@ separator {
   color: transparent;
   background-color: transparent;
 }
+
+.dialog-vbox {
+	padding: 12px;
+}

--- a/data/style.css
+++ b/data/style.css
@@ -1,3 +1,16 @@
+.inline-toolbar button.flat {
+	border-radius: 9999px;
+	border: none;
+	background-color: transparent;
+	background-image: none;
+	box-shadow: none;
+	-gtk-outline-radius: 9999px;
+}
+
+.inline-toolbar button.flat:hover {
+	background-color: alpha(@theme_fg_color, 0.2);
+}
+
 #Title {
 	padding-top: 50px;
 	font-size: 18px;

--- a/repoman/settings.py
+++ b/repoman/settings.py
@@ -69,6 +69,7 @@ class Settings(Gtk.Box):
         self.checks_grid.set_margin_top(24)
         self.checks_grid.set_margin_right(12)
         self.checks_grid.set_margin_bottom(12)
+        self.checks_grid.set_row_spacing(12)
         settings_grid.attach(self.checks_grid, 0, 2, 1, 1)
 
         developer_options = Gtk.Expander()
@@ -80,6 +81,7 @@ class Settings(Gtk.Box):
         self.developer_grid.set_margin_top(12)
         self.developer_grid.set_margin_right(12)
         self.developer_grid.set_margin_bottom(12)
+        self.developer_grid.set_row_spacing(12)
         developer_options.add(self.developer_grid)
 
         developer_label = Gtk.Label(_("These options are those which are primarily of interest to developers."))

--- a/repoman/settings.py
+++ b/repoman/settings.py
@@ -69,7 +69,7 @@ class Settings(Gtk.Box):
         self.checks_grid.set_margin_top(24)
         self.checks_grid.set_margin_right(12)
         self.checks_grid.set_margin_bottom(12)
-        self.checks_grid.set_row_spacing(12)
+        self.checks_grid.set_spacing(12)
         settings_grid.attach(self.checks_grid, 0, 2, 1, 1)
 
         developer_options = Gtk.Expander()
@@ -81,7 +81,7 @@ class Settings(Gtk.Box):
         self.developer_grid.set_margin_top(12)
         self.developer_grid.set_margin_right(12)
         self.developer_grid.set_margin_bottom(12)
-        self.developer_grid.set_row_spacing(12)
+        self.developer_grid.set_spacing(12)
         developer_options.add(self.developer_grid)
 
         developer_label = Gtk.Label(_("These options are those which are primarily of interest to developers."))

--- a/repoman/updates.py
+++ b/repoman/updates.py
@@ -72,6 +72,7 @@ class Updates(Gtk.Box):
         self.checks_grid.set_margin_top(24)
         self.checks_grid.set_margin_right(12)
         self.checks_grid.set_margin_bottom(12)
+        self.checks_grid.set_row_spacing(12)
         updates_grid.attach(self.checks_grid, 0, 2, 1, 1)
 
         separator = Gtk.HSeparator()

--- a/repoman/updates.py
+++ b/repoman/updates.py
@@ -72,7 +72,7 @@ class Updates(Gtk.Box):
         self.checks_grid.set_margin_top(24)
         self.checks_grid.set_margin_right(12)
         self.checks_grid.set_margin_bottom(12)
-        self.checks_grid.set_row_spacing(12)
+        self.checks_grid.set_spacing(12)
         updates_grid.attach(self.checks_grid, 0, 2, 1, 1)
 
         separator = Gtk.HSeparator()


### PR DESCRIPTION
The current way Repoman is set up will cause issues with some themes, including the reworking of the Pop theme currently underway for 19.10. It will need these changes, which have the benefit of fixing Repoman on other themes (like Adwaita and Yaru).

The Appearance with the current Pop theme should be only minimally affected

Fixes #21 