### PR TITLE
Flatpak support

### DIFF
--- a/repoman/dialog.py
+++ b/repoman/dialog.py
@@ -42,7 +42,7 @@ class ErrorDialog(Gtk.Dialog):
         formatter = logging.Formatter('%(asctime)s %(name)-12s %(levelname)-8s %(message)s')
         handler.setFormatter(formatter)
         self.log.addHandler(handler)
-        self.log.setLevel(logging.WARNING)
+
 
         content_area = self.get_content_area()
 
@@ -87,7 +87,7 @@ class DeleteDialog(Gtk.Dialog):
         formatter = logging.Formatter('%(asctime)s %(name)-12s %(levelname)-8s %(message)s')
         handler.setFormatter(formatter)
         self.log.addHandler(handler)
-        self.log.setLevel(logging.WARNING)
+
 
         content_area = self.get_content_area()
 
@@ -139,7 +139,7 @@ class AddDialog(Gtk.Dialog):
         formatter = logging.Formatter('%(asctime)s %(name)-12s %(levelname)-8s %(message)s')
         handler.setFormatter(formatter)
         self.log.addHandler(handler)
-        self.log.setLevel(logging.WARNING)
+
 
         self.ppa = PPA(parent)
 
@@ -217,7 +217,7 @@ class EditDialog(Gtk.Dialog):
         formatter = logging.Formatter('%(asctime)s %(name)-12s %(levelname)-8s %(message)s')
         handler.setFormatter(formatter)
         self.log.addHandler(handler)
-        self.log.setLevel(logging.WARNING)
+
 
         self.ppa = PPA(self)
         self.parent = parent

--- a/repoman/flatpak.py
+++ b/repoman/flatpak.py
@@ -164,10 +164,7 @@ class Flatpak(Gtk.Box):
         self.settings = Gtk.Settings()
 
         self.log = logging.getLogger("repoman.Flatpak")
-        handler = logging.StreamHandler()
-        formatter = logging.Formatter('%(asctime)s %(name)-12s %(levelname)-8s %(message)s')
-        handler.setFormatter(formatter)
-        self.log.addHandler(handler)
+        self.log.debug('Logging established')
 
 
         self.content_grid = Gtk.Grid()

--- a/repoman/flatpak.py
+++ b/repoman/flatpak.py
@@ -1,0 +1,147 @@
+#!/usr/bin/python3
+'''
+   Copyright 2017 Mirko Brombin (brombinmirko@gmail.com)
+   Copyright 2017 Ian Santopietro (ian@system76.com)
+
+   This file is part of Repoman.
+
+    Repoman is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Repoman is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Repoman.  If not, see <http://www.gnu.org/licenses/>.
+'''
+
+import gi
+import logging
+gi.require_version('Gtk', '3.0')
+from gi.repository import Gtk
+
+import pyflatpak
+
+from .dialog import AddDialog, EditDialog
+import gettext
+gettext.bindtextdomain('repoman', '/usr/share/repoman/po')
+gettext.textdomain("repoman")
+_ = gettext.gettext
+
+class Flatpak(Gtk.Box):
+
+    listiter_count = 0
+    ppa_name = False
+
+    def __init__(self, parent):
+        Gtk.Box.__init__(self, False, 0)
+        self.parent = parent
+
+        self.settings = Gtk.Settings()
+
+        self.log = logging.getLogger("repoman.Flatpak")
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter('%(asctime)s %(name)-12s %(levelname)-8s %(message)s')
+        handler.setFormatter(formatter)
+        self.log.addHandler(handler)
+        self.log.setLevel(logging.WARNING)
+
+        self.content_grid = Gtk.Grid()
+        self.content_grid.set_margin_left(12)
+        self.content_grid.set_margin_top(24)
+        self.content_grid.set_margin_right(12)
+        self.content_grid.set_margin_bottom(12)
+        self.content_grid.set_hexpand(True)
+        self.content_grid.set_vexpand(True)
+        self.add(self.content_grid)
+
+        sources_title = Gtk.Label(_("Flatpak Sources"))
+        sources_title.set_halign(Gtk.Align.START)
+        Gtk.StyleContext.add_class(sources_title.get_style_context(), "h2")
+        self.content_grid.attach(sources_title, 0, 0, 1, 1)
+
+        sources_label = Gtk.Label(_("These sources are for software provided via Flatpak. They may present a security risk. Only add sources that you trust."))
+        sources_label.set_line_wrap(True)
+        sources_label.set_justify(Gtk.Justification.FILL)
+        sources_label.set_halign(Gtk.Align.START)
+        Gtk.StyleContext.add_class(sources_label.get_style_context(), "description")
+        self.content_grid.attach(sources_label, 0, 1, 1, 1)
+
+        list_grid = Gtk.Grid()
+        self.content_grid.attach(list_grid, 0, 2, 1, 1)
+        list_window = Gtk.ScrolledWindow()
+        Gtk.StyleContext.add_class(list_window.get_style_context(), "list_window")
+        list_grid.attach(list_window, 0, 0, 1, 1)
+
+        self.ppa_liststore = Gtk.ListStore(str, str)
+        self.view = Gtk.TreeView(self.ppa_liststore)
+        renderer = Gtk.CellRendererText()
+        column = Gtk.TreeViewColumn(_("Source"), renderer, markup=0)
+        self.view.append_column(column)
+        self.view.set_hexpand(True)
+        self.view.set_vexpand(True)
+        self.view.connect("row-activated", self.on_row_activated)
+        tree_selection = self.view.get_selection()
+        tree_selection.connect('changed', self.on_row_change)
+        list_window.add(self.view)
+
+        # add button
+        add_button = Gtk.ToolButton()
+        add_button.set_icon_name("list-add-symbolic")
+        Gtk.StyleContext.add_class(add_button.get_style_context(),
+                                   "image-button")
+        add_button.set_tooltip_text(_("Add New Source"))
+        add_button.connect("clicked", self.on_add_button_clicked)
+
+        # edit button
+        delete_button = Gtk.ToolButton()
+        delete_button.set_icon_name("edit-delete-symbolic")
+        Gtk.StyleContext.add_class(delete_button.get_style_context(),
+                                   "image-button")
+        delete_button.set_tooltip_text(_("Remove Selected Source"))
+        delete_button.connect("clicked", self.on_delete_button_clicked)
+
+        action_bar = Gtk.Toolbar()
+        action_bar.set_icon_size(Gtk.IconSize.SMALL_TOOLBAR)
+        Gtk.StyleContext.add_class(action_bar.get_style_context(),
+                                   "inline-toolbar")
+        action_bar.insert(delete_button, 0)
+        action_bar.insert(add_button, 0)
+        list_grid.attach(action_bar, 0, 1, 1, 1)
+
+        self.generate_entries()
+
+    def on_delete_button_clicked(self, widget):
+        pass
+
+    def on_row_activated(self, widget, data1, data2):
+        tree_iter = self.ppa_liststore.get_iter(data1)
+        value = self.ppa_liststore.get_value(tree_iter, 1)
+        self.log.info("PPA to edit: %s" % value)
+
+    def do_edit(self, repo):
+        pass
+        
+
+    def on_add_button_clicked(self, widget):
+        pass
+
+    def generate_entries(self):
+        pass
+
+    def on_row_change(self, widget):
+        (model, pathlist) = widget.get_selected_rows()
+        for path in pathlist :
+            print(pathlist) #DEBUG
+
+    def throw_error_dialog(self, message, msg_type):
+        if msg_type == "error":
+            msg_type = Gtk.MessageType.ERROR
+        dialog = Gtk.MessageDialog(self.parent.parent, 0, msg_type,
+                                   Gtk.ButtonsType.CLOSE, message)
+        dialog.run()
+        dialog.destroy()

--- a/repoman/flatpak.py
+++ b/repoman/flatpak.py
@@ -265,7 +265,7 @@ class Flatpak(Gtk.Box):
         self.view.append_column(url_column)
 
         option_renderer = Gtk.CellRendererText()
-        option_column = Gtk.TreeViewColumn(_('Option'), option_renderer, markup=4)
+        option_column = Gtk.TreeViewColumn(_('Type'), option_renderer, markup=4)
         option_column.set_min_width(80)
         self.view.append_column(option_column)
 

--- a/repoman/flatpak.py
+++ b/repoman/flatpak.py
@@ -50,7 +50,7 @@ class AddDialog(Gtk.Dialog):
         formatter = logging.Formatter('%(asctime)s %(name)-12s %(levelname)-8s %(message)s')
         handler.setFormatter(formatter)
         self.log.addHandler(handler)
-        self.log.setLevel(logging.WARNING)
+
 
         content_area = self.get_content_area()
 
@@ -120,7 +120,7 @@ class DeleteDialog(Gtk.Dialog):
         formatter = logging.Formatter('%(asctime)s %(name)-12s %(levelname)-8s %(message)s')
         handler.setFormatter(formatter)
         self.log.addHandler(handler)
-        self.log.setLevel(logging.WARNING)
+
 
         content_area = self.get_content_area()
 
@@ -168,7 +168,7 @@ class Flatpak(Gtk.Box):
         formatter = logging.Formatter('%(asctime)s %(name)-12s %(levelname)-8s %(message)s')
         handler.setFormatter(formatter)
         self.log.addHandler(handler)
-        self.log.setLevel(logging.DEBUG)
+
 
         self.content_grid = Gtk.Grid()
         self.content_grid.set_margin_left(12)

--- a/repoman/flatpak.py
+++ b/repoman/flatpak.py
@@ -71,6 +71,7 @@ class AddDialog(Gtk.Dialog):
         self.name_entry = Gtk.Entry()
         self.name_entry.set_placeholder_text(_("Source Name"))
         self.name_entry.set_activates_default(True)
+        self.name_entry.connect(_("changed"), self.on_name_entry_changed)
         self.name_entry.set_width_chars(20)
         self.name_entry.set_margin_top(12)
         content_grid.attach(self.name_entry, 0, 1, 1, 1)
@@ -78,7 +79,7 @@ class AddDialog(Gtk.Dialog):
         self.url_entry = Gtk.Entry()
         self.url_entry.set_placeholder_text(_("URL"))
         self.url_entry.set_activates_default(True)
-        self.url_entry.connect(_("changed"), self.on_entry_changed)
+        self.url_entry.connect(_("changed"), self.on_url_entry_changed)
         self.url_entry.set_width_chars(50)
         self.url_entry.set_margin_top(12)
         content_grid.attach(self.url_entry, 1, 1, 1, 1)
@@ -92,13 +93,48 @@ class AddDialog(Gtk.Dialog):
 
         self.show_all()
 
-    def on_entry_changed(self, widget):
+    def on_url_entry_changed(self, widget):
         entry_text = widget.get_text()
         entry_valid = flatpak.validate(entry_text)
         try:
             self.add_button.set_sensitive(entry_valid)
         except TypeError:
             pass
+    
+    def on_name_entry_changed(self, widget):
+        # Filter out some special characters, which may not be allowed by spec
+        # and are likely to cause frustration for users who later use the 
+        # Flatpak CLI.
+        replacements = {
+            ' ': '-',
+            '%': '',
+            '(': '',
+            ')': '',
+            '{': '',
+            '}': '',
+            '[': '',
+            ']': '',
+            '#': '',
+            '~': '',
+            '"': '',
+            "'": '',
+            '\\': '',
+            '/': '',
+            '|': '',
+            '&': '',
+            '`': '',
+            '*': '',
+            ';': '',
+            ':': ''
+        }
+        entry_text = self.name_entry.get_text()
+        self.log.debug('Validating name: %s', entry_text)
+        print(entry_text)
+
+        # Perform the filtering:
+        for char in replacements:
+            entry_text = entry_text.replace(char, replacements[char])
+        self.name_entry.set_text(entry_text)
 
 class DeleteDialog(Gtk.Dialog):
 

--- a/repoman/flatpak.py
+++ b/repoman/flatpak.py
@@ -73,7 +73,7 @@ class AddDialog(Gtk.Dialog):
         self.name_entry.set_activates_default(True)
         self.name_entry.set_width_chars(20)
         self.name_entry.set_margin_top(12)
-        content_grid.attach(self.name_entry, 0, 2, 1, 1)
+        content_grid.attach(self.name_entry, 0, 1, 1, 1)
 
         self.url_entry = Gtk.Entry()
         self.url_entry.set_placeholder_text(_("URL"))
@@ -81,7 +81,7 @@ class AddDialog(Gtk.Dialog):
         self.url_entry.connect(_("changed"), self.on_entry_changed)
         self.url_entry.set_width_chars(50)
         self.url_entry.set_margin_top(12)
-        content_grid.attach(self.url_entry, 0, 2, 1, 1)
+        content_grid.attach(self.url_entry, 1, 1, 1, 1)
 
         self.add_button = self.get_widget_for_response(Gtk.ResponseType.OK)
         self.add_button.set_sensitive(False)
@@ -114,7 +114,7 @@ class Flatpak(Gtk.Box):
         formatter = logging.Formatter('%(asctime)s %(name)-12s %(levelname)-8s %(message)s')
         handler.setFormatter(formatter)
         self.log.addHandler(handler)
-        self.log.setLevel(logging.WARNING)
+        self.log.setLevel(logging.DEBUG)
 
         self.content_grid = Gtk.Grid()
         self.content_grid.set_margin_left(12)
@@ -206,12 +206,18 @@ class Flatpak(Gtk.Box):
     def on_add_button_clicked(self, widget):
         dialog = AddDialog(self.parent.parent)
         response = dialog.run()
+        self.log.debug('Response type: %s', response)
 
-        if response is Gtk.ResponseType.OK:
+        if response == Gtk.ResponseType.OK:
             name = dialog.name_entry.get_text()
             url = dialog.url_entry.get_text()
+            self.log.info('Adding flatpak source %s at %s', name, url)
             dialog.destroy()
             flatpak.remotes.add_remote(name, url)
+        else:
+            dialog.destroy()
+        
+        self.generate_entries()
 
     def generate_entries(self):
         self.remote_liststore.clear()

--- a/repoman/list.py
+++ b/repoman/list.py
@@ -49,7 +49,7 @@ class List(Gtk.Box):
         formatter = logging.Formatter('%(asctime)s %(name)-12s %(levelname)-8s %(message)s')
         handler.setFormatter(formatter)
         self.log.addHandler(handler)
-        self.log.setLevel(logging.WARNING)
+
 
         self.content_grid = Gtk.Grid()
         self.content_grid.set_margin_left(12)

--- a/repoman/list.py
+++ b/repoman/list.py
@@ -45,10 +45,7 @@ class List(Gtk.Box):
         self.settings = Gtk.Settings()
 
         self.log = logging.getLogger("repoman.List")
-        handler = logging.StreamHandler()
-        formatter = logging.Formatter('%(asctime)s %(name)-12s %(levelname)-8s %(message)s')
-        handler.setFormatter(formatter)
-        self.log.addHandler(handler)
+        self.log.debug('Logging established')
 
 
         self.content_grid = Gtk.Grid()

--- a/repoman/main.py
+++ b/repoman/main.py
@@ -39,19 +39,6 @@ class Application(Gtk.Application):
 
     def do_activate(self):
 
-        self.log = logging.getLogger("repoman.Updates")
-        handler = logging.StreamHandler()
-        formatter = logging.Formatter('%(asctime)s %(name)-12s %(levelname)-8s %(message)s')
-        handler.setFormatter(formatter)
-        handler.setLevel(logging.WARNING)
-        self.log.addHandler(handler)
-
-        if JournalHandler:
-            journald_log = JournalHandler()
-            journald_log.setLevel(logging.INFO)
-            journald_log.setFormatter(formatter)
-            self.log.addHandler(journald_log)
-
         self.win = Window()
         self.win.set_default_size(700, 400)
         self.win.connect("delete-event", self.application_quit)

--- a/repoman/main.py
+++ b/repoman/main.py
@@ -24,6 +24,12 @@ import logging
 import gi
 gi.require_version('Gtk', '3.0')
 from gi.repository import Gtk, Gdk
+
+try:
+    from systemd.journal import JournalHandler
+except ImportError:
+    JournalHandler = False
+
 from .window import Window
 
 bus = dbus.SystemBus()
@@ -37,8 +43,14 @@ class Application(Gtk.Application):
         handler = logging.StreamHandler()
         formatter = logging.Formatter('%(asctime)s %(name)-12s %(levelname)-8s %(message)s')
         handler.setFormatter(formatter)
+        handler.setLevel(logging.WARNING)
         self.log.addHandler(handler)
-        self.log.setLevel(logging.WARNING)
+
+        if JournalHandler:
+            journald_log = JournalHandler()
+            journald_log.setLevel(logging.INFO)
+            journald_log.setFormatter(formatter)
+            self.log.addHandler(journald_log)
 
         self.win = Window()
         self.win.set_default_size(700, 400)

--- a/repoman/ppa.py
+++ b/repoman/ppa.py
@@ -45,10 +45,7 @@ class RemoveThread(threading.Thread):
         self.sp = sp
 
         self.log = logging.getLogger("repoman.PPA.RemoveThread")
-        handler = logging.StreamHandler()
-        formatter = logging.Formatter('%(asctime)s %(name)-12s %(levelname)-8s %(message)s')
-        handler.setFormatter(formatter)
-        self.log.addHandler(handler)
+        self.log.debug('Logging established')
 
 
     def run(self):
@@ -82,10 +79,7 @@ class AddThread(threading.Thread):
         self.sp = sp
 
         self.log = logging.getLogger("repoman.PPA.AddThread")
-        handler = logging.StreamHandler()
-        formatter = logging.Formatter('%(asctime)s %(name)-12s %(levelname)-8s %(message)s')
-        handler.setFormatter(formatter)
-        self.log.addHandler(handler)
+        self.log.debug('Logging established')
 
 
     def run(self):
@@ -121,10 +115,7 @@ class ModifyThread(threading.Thread):
         self.sp = sp
 
         self.log = logging.getLogger("repoman.PPA.ModifyThread")
-        handler = logging.StreamHandler()
-        formatter = logging.Formatter('%(asctime)s %(name)-12s %(levelname)-8s %(message)s')
-        handler.setFormatter(formatter)
-        self.log.addHandler(handler)
+        self.log.debug('Logging established')
 
 
     def run(self):
@@ -159,10 +150,7 @@ class PPA:
         self.parent = parent
 
         self.log = logging.getLogger("repoman.PPA")
-        handler = logging.StreamHandler()
-        formatter = logging.Formatter('%(asctime)s %(name)-12s %(levelname)-8s %(message)s')
-        handler.setFormatter(formatter)
-        self.log.addHandler(handler)
+        self.log.debug('Logging established')
 
 
     # Returns a list of all 3rd-party software sources.

--- a/repoman/ppa.py
+++ b/repoman/ppa.py
@@ -158,7 +158,7 @@ class PPA:
     def __init__(self, parent):
         self.parent = parent
 
-        self.log = logging.getLogger("repoman.Updates")
+        self.log = logging.getLogger("repoman.PPA")
         handler = logging.StreamHandler()
         formatter = logging.Formatter('%(asctime)s %(name)-12s %(levelname)-8s %(message)s')
         handler.setFormatter(formatter)

--- a/repoman/ppa.py
+++ b/repoman/ppa.py
@@ -49,7 +49,7 @@ class RemoveThread(threading.Thread):
         formatter = logging.Formatter('%(asctime)s %(name)-12s %(levelname)-8s %(message)s')
         handler.setFormatter(formatter)
         self.log.addHandler(handler)
-        self.log.setLevel(logging.WARNING)
+
 
     def run(self):
         self.log.info( "Removing PPA %s" % (self.ppa) )
@@ -86,7 +86,7 @@ class AddThread(threading.Thread):
         formatter = logging.Formatter('%(asctime)s %(name)-12s %(levelname)-8s %(message)s')
         handler.setFormatter(formatter)
         self.log.addHandler(handler)
-        self.log.setLevel(logging.WARNING)
+
 
     def run(self):
         self.log.info("Adding PPA %s" % (self.url))
@@ -125,7 +125,7 @@ class ModifyThread(threading.Thread):
         formatter = logging.Formatter('%(asctime)s %(name)-12s %(levelname)-8s %(message)s')
         handler.setFormatter(formatter)
         self.log.addHandler(handler)
-        self.log.setLevel(logging.WARNING)
+
 
     def run(self):
         try:
@@ -163,7 +163,7 @@ class PPA:
         formatter = logging.Formatter('%(asctime)s %(name)-12s %(levelname)-8s %(message)s')
         handler.setFormatter(formatter)
         self.log.addHandler(handler)
-        self.log.setLevel(logging.WARNING)
+
 
     # Returns a list of all 3rd-party software sources.
     def get_isv(self):

--- a/repoman/repoman
+++ b/repoman/repoman
@@ -31,7 +31,7 @@ formatter = logging.Formatter('%(asctime)s %(name)-12s %(levelname)-8s %(message
 log = logging.getLogger("repoman")
 handler = logging.StreamHandler()
 handler.setFormatter(formatter)
-handler.setLevel(logging.DEBUG)
+handler.setLevel(logging.WARNING)
 log.addHandler(handler)
 
 if JournalHandler:

--- a/repoman/repoman
+++ b/repoman/repoman
@@ -18,8 +18,31 @@
     You should have received a copy of the GNU General Public License
     along with Repoman.  If not, see <http://www.gnu.org/licenses/>.
 '''
+import logging
 import os
 import sys
+
+try:
+    from systemd.journal import JournalHandler
+except ImportError:
+    JournalHandler = False
+
+log = logging.getLogger("repoman")
+handler = logging.StreamHandler()
+formatter = logging.Formatter('%(asctime)s %(name)-12s %(levelname)-8s %(message)s')
+handler.setFormatter(formatter)
+handler.setLevel(logging.WARNING)
+log.addHandler(handler)
+log.setLevel(logging.DEBUG)
+
+if JournalHandler:
+    journald_log = JournalHandler()
+    journald_log.setLevel(logging.INFO)
+    journald_log.setFormatter(formatter)
+    log.addHandler(journald_log)
+
+log.debug('Logging established')
+
 from repoman import main
 
     

--- a/repoman/repoman
+++ b/repoman/repoman
@@ -31,7 +31,10 @@ formatter = logging.Formatter('%(asctime)s %(name)-12s %(levelname)-8s %(message
 log = logging.getLogger("repoman")
 handler = logging.StreamHandler()
 handler.setFormatter(formatter)
-handler.setLevel(logging.WARNING)
+if len(sys.argv) > 1:
+    handler.setLevel(logging.DEBUG)
+else:
+    handler.setLevel(logging.WARNING)
 log.addHandler(handler)
 
 if JournalHandler:

--- a/repoman/repoman
+++ b/repoman/repoman
@@ -31,7 +31,7 @@ formatter = logging.Formatter('%(asctime)s %(name)-12s %(levelname)-8s %(message
 log = logging.getLogger("repoman")
 handler = logging.StreamHandler()
 handler.setFormatter(formatter)
-handler.setLevel(logging.WARNING)
+handler.setLevel(logging.DEBUG)
 log.addHandler(handler)
 
 if JournalHandler:

--- a/repoman/repoman
+++ b/repoman/repoman
@@ -27,19 +27,21 @@ try:
 except ImportError:
     JournalHandler = False
 
+formatter = logging.Formatter('%(asctime)s %(name)-12s %(levelname)-8s %(message)s')
 log = logging.getLogger("repoman")
 handler = logging.StreamHandler()
-formatter = logging.Formatter('%(asctime)s %(name)-12s %(levelname)-8s %(message)s')
 handler.setFormatter(formatter)
 handler.setLevel(logging.WARNING)
 log.addHandler(handler)
-log.setLevel(logging.DEBUG)
 
 if JournalHandler:
     journald_log = JournalHandler()
     journald_log.setLevel(logging.INFO)
     journald_log.setFormatter(formatter)
     log.addHandler(journald_log)
+    log.info('Setup journald logging')
+
+log.setLevel(logging.DEBUG)
 
 log.debug('Logging established')
 

--- a/repoman/settings.py
+++ b/repoman/settings.py
@@ -21,6 +21,7 @@
 
 import dbus
 import gi
+import logging
 gi.require_version('Gtk', '3.0')
 from gi.repository import Gtk
 from .ppa import PPA
@@ -35,6 +36,8 @@ class Settings(Gtk.Box):
         Gtk.Box.__init__(self, False, 0)
 
         self.ppa = PPA(self)
+        self.log = logging.getLogger('repoman.Settings')
+        self.log.debug('Logging established.')
         self.os_name = self.ppa.get_os_name()
         self.handlers = {}
 

--- a/repoman/stack.py
+++ b/repoman/stack.py
@@ -25,6 +25,10 @@ from gi.repository import Gtk
 from .settings import Settings
 from .updates import Updates
 from .list import List
+try:
+    from .flatpak import Flatpak
+except ImportError:
+    Flatpak = False
 import gettext
 gettext.bindtextdomain('repoman', '/usr/share/repoman/po')
 gettext.textdomain("repoman")
@@ -43,10 +47,14 @@ class Stack(Gtk.Box):
         self.setting = Settings(self)
         self.updates = Updates(self)
         self.list_all = List(self)
+        if Flatpak:
+            self.flatpak = Flatpak(self)
 
         self.stack.add_titled(self.setting, "settings", _("Settings"))
         self.stack.add_titled(self.updates, "updates", _("Updates"))
         self.stack.add_titled(self.list_all, "list", _("Extra Sources"))
+        if Flatpak:
+            self.stack.add_titled(self.flatpak, "flatpak", _("Flatpak"))
 
         self.pack_start(self.stack, True, True, 0)
 

--- a/repoman/updates.py
+++ b/repoman/updates.py
@@ -36,10 +36,7 @@ class Updates(Gtk.Box):
         Gtk.Box.__init__(self, False, 0)
 
         self.log = logging.getLogger("repoman.Updates")
-        handler = logging.StreamHandler()
-        formatter = logging.Formatter('%(asctime)s %(name)-12s %(levelname)-8s %(message)s')
-        handler.setFormatter(formatter)
-        self.log.addHandler(handler)
+        self.log.debug('Logging established')
 
 
         self.parent = parent

--- a/repoman/updates.py
+++ b/repoman/updates.py
@@ -40,7 +40,7 @@ class Updates(Gtk.Box):
         formatter = logging.Formatter('%(asctime)s %(name)-12s %(levelname)-8s %(message)s')
         handler.setFormatter(formatter)
         self.log.addHandler(handler)
-        self.log.setLevel(logging.WARNING)
+
 
         self.parent = parent
 


### PR DESCRIPTION
Adds support for adding, listing, and removing Flatpak remotes in Repoman.

This is done conditionally depending on present of a Flatpak support library (pyflatpak) which needs to be present to show the new UI. Without this library, the Flatpak tab is hidden.

Once the library is installed, the tab is available and can be interacted with. It allows removing and listing all currently configured flatpak remotes, both user and system level. It also adds user-level remotes, given a name and a URL to the .flatpakrepo file (with input validation to ensure this looks correct).

For testing this, we should test that installing this does not modify the existing experience on a regular 19.10 installation, as well as checking the actual functionality with pyflatpak installed.

Testing:

 - [ ] Updated Repoman continues to function as presently, without showing the flatpak tab, when pyflatpak is not installed
 - [ ] Flatpak tab shows when pyflatpak is installed.
 - [ ] Adding a flatpak remote (e.g. flathub, https://flathub.org/repo/flathub.flatpakrepo) shows it in the list
 - [ ] Apps can be installed from added flatpak remotes
 - [ ] Configured flatpak remotes are shown in the list.
 - [ ] Flatpak remotes can be removed from the system
 - [ ] If a flatpak remote is added from the command line (`flatpak remote-add --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo`) it is shown in Repoman after restarting the application.
 - [ ] Adding the same flatpak remote twice only adds it once.
 - [ ] If a flatpak remote is removed in Repoman, all applications installed from it are also removed.