### PR TITLE
Update git instructions for Pop! repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ sudo apt install repoman
 Additionally, you can use **git**:
 
 ```bash
-git clone https://github.com/isantop/repoman.git
+git clone https://github.com/pop-os/repoman.git
 cd repoman
 sudo python3 setup.py install
 ```


### PR DESCRIPTION
The 'install from git' instructions tell you to clone from the old repository, the one owned by isantop. If merged, users will be instructed to clone from pop-os/repoman instead of isantop/repoman.