### PR TITLE
fix: Re-align developer_label to be aligned START

### DIFF
--- a/repoman/settings.py
+++ b/repoman/settings.py
@@ -87,6 +87,7 @@ class Settings(Gtk.Box):
         developer_label = Gtk.Label(_("These options are those which are primarily of interest to developers."))
         developer_label.set_line_wrap(True)
         developer_label.set_halign(Gtk.Align.START)
+        developer_label.set_margin_start(5)
         self.developer_grid.add(developer_label)
         self.developer_grid.add(self.source_check)
         self.developer_grid.add(self.proposed_check)

--- a/repoman/settings.py
+++ b/repoman/settings.py
@@ -86,6 +86,7 @@ class Settings(Gtk.Box):
 
         developer_label = Gtk.Label(_("These options are those which are primarily of interest to developers."))
         developer_label.set_line_wrap(True)
+        developer_label.set_halign(Gtk.Align.START)
         self.developer_grid.add(developer_label)
         self.developer_grid.add(self.source_check)
         self.developer_grid.add(self.proposed_check)


### PR DESCRIPTION
Small label formatting fix. 

Fixes #12 