### PR TITLE
fix: Remove Recommends as it's causing the upgrade to be held back

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -16,7 +16,6 @@ Depends: ${python3:Depends}, ${misc:Depends},
          software-properties-common,
          gir1.2-gtk-3.0,
          python-requests,
-Recommends: python3-pyflatpak
 Description: Repoman
  Hey man, let's go do crimes. Yeah, let's install software and not pay.
 


### PR DESCRIPTION
Removes the `python3-pyflatpak` recommends as it seems to be causing issues upgrading to the new version of repoman.

This should probably be considered high-priority.