### PR TITLE
Apt delete button

### DIFF
--- a/repoman/dialog.py
+++ b/repoman/dialog.py
@@ -288,13 +288,6 @@ class EditDialog(Gtk.Dialog):
         self.enabled_switch.set_active(not repo_disabled)
         content_grid.attach(self.enabled_switch, 1, 4, 1, 1)
 
-
-        remove_button = Gtk.Button.new_with_label(_("Remove Source"))
-        Gtk.StyleContext.add_class(remove_button.get_style_context(),
-                                   "destructive-action")
-        remove_button.connect("clicked", self.on_remove_button_clicked)
-        #content_grid.attach(remove_button, 0, 5, 1, 1)
-
         save_button = self.get_widget_for_response(Gtk.ResponseType.OK)
         cancel_button = self.get_widget_for_response(Gtk.ResponseType.CANCEL)
 
@@ -303,7 +296,6 @@ class EditDialog(Gtk.Dialog):
 
 
         action_area = self.get_action_area()
-        action_area.add(remove_button)
         separator = Gtk.Box()
         separator.set_hexpand(True)
         action_area.add(separator)
@@ -322,17 +314,3 @@ class EditDialog(Gtk.Dialog):
             action_area.remove(cancel_button)
             action_area.add(cancel_button)
             action_area.add(save_button)
-
-    def on_remove_button_clicked(self, widget):
-        self.log.debug("Remove Clicked")
-        dialog = DeleteDialog(self)
-        response = dialog.run()
-
-        if response == Gtk.ResponseType.OK:
-            self.ppa.remove(self.repo_whole)
-            dialog.destroy()
-            self.destroy()
-        else:
-            dialog.destroy()
-
-

--- a/repoman/list.py
+++ b/repoman/list.py
@@ -114,9 +114,9 @@ class List(Gtk.Box):
         action_bar.set_icon_size(Gtk.IconSize.SMALL_TOOLBAR)
         Gtk.StyleContext.add_class(action_bar.get_style_context(),
                                    "inline-toolbar")
+        action_bar.insert(delete_button, 0)
         action_bar.insert(edit_button, 0)
         action_bar.insert(add_button, 0)
-        action_bar.insert(delete_button, 0)
         list_grid.attach(action_bar, 0, 1, 1, 1)
 
         self.generate_entries(self.ppa.get_isv())

--- a/repoman/list.py
+++ b/repoman/list.py
@@ -25,7 +25,7 @@ gi.require_version('Gtk', '3.0')
 from gi.repository import Gtk
 from softwareproperties.SoftwareProperties import SoftwareProperties
 from .ppa import PPA
-from .dialog import AddDialog, EditDialog, ErrorDialog
+from .dialog import AddDialog, EditDialog, ErrorDialog, DeleteDialog
 import gettext
 gettext.bindtextdomain('repoman', '/usr/share/repoman/po')
 gettext.textdomain("repoman")
@@ -102,15 +102,43 @@ class List(Gtk.Box):
         edit_button.set_tooltip_text(_("Modify Selected Source"))
         edit_button.connect("clicked", self.on_edit_button_clicked)
 
+        # delete button
+        delete_button = Gtk.ToolButton()
+        delete_button.set_icon_name("edit-delete-symbolic")
+        Gtk.StyleContext.add_class(delete_button.get_style_context(),
+                                   "image-button")
+        delete_button.set_tooltip_text(_("Modify Selected Source"))
+        delete_button.connect("clicked", self.on_delete_button_clicked)
+
         action_bar = Gtk.Toolbar()
         action_bar.set_icon_size(Gtk.IconSize.SMALL_TOOLBAR)
         Gtk.StyleContext.add_class(action_bar.get_style_context(),
                                    "inline-toolbar")
         action_bar.insert(edit_button, 0)
         action_bar.insert(add_button, 0)
+        action_bar.insert(delete_button, 0)
         list_grid.attach(action_bar, 0, 1, 1, 1)
 
         self.generate_entries(self.ppa.get_isv())
+    
+    def on_delete_button_clicked(self, widget):
+        selec = self.view.get_selection()
+        (model, pathlist) = selec.get_selected_rows()
+        tree_iter = model.get_iter(pathlist[0])
+        value = model.get_value(tree_iter, 1)
+        self.log.debug('Deleting PPA: %s', value)
+        self.do_delete(value)
+    
+    def do_delete(self, repo):
+        dialog = DeleteDialog(self.parent.parent)
+        response = dialog.run()
+
+        if response == Gtk.ResponseType.OK:
+            self.ppa.remove(repo)
+            dialog.destroy()
+        
+        else:
+            dialog.destroy()
 
     def on_edit_button_clicked(self, widget):
         selec = self.view.get_selection()

--- a/repoman/ppa.py
+++ b/repoman/ppa.py
@@ -62,9 +62,9 @@ class RemoveThread(threading.Thread):
             self.log.warn(self.exc[1])
             self.throw_error(self.exc[1])
         isv_list = self.sp.get_isv_sources()
-        GObject.idle_add(self.parent.parent.stack.list_all.generate_entries, isv_list)
-        GObject.idle_add(self.parent.parent.stack.list_all.view.set_sensitive, True)
-        GObject.idle_add(self.parent.parent.hbar.spinner.stop)
+        GObject.idle_add(self.parent.parent.parent.stack.list_all.generate_entries, isv_list)
+        GObject.idle_add(self.parent.parent.parent.stack.list_all.view.set_sensitive, True)
+        GObject.idle_add(self.parent.parent.parent.hbar.spinner.stop)
 
     def throw_error(self, message):
         GObject.idle_add(self.parent.parent.stack.list_all.throw_error_dialog,
@@ -249,8 +249,8 @@ class PPA:
 
     # Starts a new thread to remove a repository
     def remove(self, ppa):
-        self.parent.parent.hbar.spinner.start()
-        self.parent.parent.stack.list_all.view.set_sensitive(False)
+        self.parent.parent.parent.hbar.spinner.start()
+        self.parent.parent.parent.stack.list_all.view.set_sensitive(False)
         RemoveThread(self.parent, self.sources_path, ppa, self.sp).start()
 
     # Validate if a line appears to be a valid apt line or ppa.


### PR DESCRIPTION
Moves the remove button for Apt sources from the edit dialog into the main window (in the action bar).

This brings the UI more in line with the Flatpak pane, and makes removing multiple sources a bit easier. 

Fixes #40 