### PR TITLE
feat: Add homepage button to the flatpak info page.

### DIFF
--- a/repoman/flatpak.py
+++ b/repoman/flatpak.py
@@ -217,10 +217,7 @@ class InfoDialog(Gtk.Dialog):
         description_label.set_width_chars(36)
         description_label.set_text(description)
         content_grid.attach(description_label, 0, 3, 1, 1)
-
-        # This is currently broken, so we don't show the button. 
-        # It will require support in pyflatpak for getting the repo
-        # homepage.
+        
         url_button = Gtk.LinkButton.new_with_label(_('Homepage'))
         url_button.set_uri(url)
         content_grid.attach(url_button, 0, 4, 1, 1)

--- a/repoman/flatpak.py
+++ b/repoman/flatpak.py
@@ -193,12 +193,7 @@ class InfoDialog(Gtk.Dialog):
 
         remote_title = self.remote_data['title']
         description = self.remote_data['about']
-        # FIXME: Pyflatpak has a bug, we want to work around this if present
-        # See https://github.com/pop-os/pyflatpak/issues/4
-        try:
-            url = self.remote_data['homepage']
-        except KeyError:
-            url = self.remote_data['hompage']
+        url = self.remote_data['homepage']
 
         title_label = Gtk.Label()
         title_label.set_line_wrap(True)

--- a/repoman/flatpak.py
+++ b/repoman/flatpak.py
@@ -161,6 +161,7 @@ class InfoDialog(Gtk.Dialog):
     def __init__(self, parent, remote, name, option):
         self.remote = remote
         self.option = option
+        self.remote_data = flatpak.remotes.remotes[option][remote]
 
         settings = Gtk.Settings.get_default()
         header = settings.props.gtk_dialogs_use_header
@@ -172,6 +173,8 @@ class InfoDialog(Gtk.Dialog):
             use_header_bar=header
         )
         self.log = logging.getLogger('repoman.FPInfoDialog')
+
+        self.log.debug('Data for remote %s: %s', remote, self.remote_data)
 
         self.set_resizable(False)
 
@@ -188,9 +191,14 @@ class InfoDialog(Gtk.Dialog):
         content_grid.set_row_spacing(6)
         content_area.add(content_grid)
 
-        remote_title = flatpak.remotes.remotes[self.option][self.remote]['title']
-        description = flatpak.remotes.remotes[self.option][self.remote]['about']
-        url = flatpak.remotes.remotes[self.option][self.remote]['url']
+        remote_title = self.remote_data['title']
+        description = self.remote_data['about']
+        # FIXME: Pyflatpak has a bug, we want to work around this if present
+        # See https://github.com/pop-os/pyflatpak/issues/4
+        try:
+            url = self.remote_data['homepage']
+        except KeyError:
+            url = self.remote_data['hompage']
 
         title_label = Gtk.Label()
         title_label.set_line_wrap(True)
@@ -210,8 +218,6 @@ class InfoDialog(Gtk.Dialog):
         description_label.set_text(description)
         content_grid.attach(description_label, 0, 3, 1, 1)
 
-        self.show_all()
-
         # This is currently broken, so we don't show the button. 
         # It will require support in pyflatpak for getting the repo
         # homepage.
@@ -219,6 +225,7 @@ class InfoDialog(Gtk.Dialog):
         url_button.set_uri(url)
         content_grid.attach(url_button, 0, 4, 1, 1)
 
+        self.show_all()
 
 class Flatpak(Gtk.Box):
 


### PR DESCRIPTION
Adds a homepage button into the Flatpak details page, so that users can easily navigate to the homepage for the remote.

fixes #34 