### PR TITLE
Remote icon

### DIFF
--- a/repoman/flatpak.py
+++ b/repoman/flatpak.py
@@ -33,6 +33,7 @@ import pyflatpak as flatpak
 from pyflatpak.remotes import AddRemoteError, DeleteRemoteError
 
 from .dialog import ErrorDialog
+from .icon import RemoteIcon
 
 import gettext
 gettext.bindtextdomain('repoman', '/usr/share/repoman/po')
@@ -191,6 +192,9 @@ class InfoDialog(Gtk.Dialog):
         remote_title = flatpak.remotes.remotes[self.option][self.remote]['title']
         description = flatpak.remotes.remotes[self.option][self.remote]['about']
         url = flatpak.remotes.remotes[self.option][self.remote]['url']
+        icon = RemoteIcon(self.remote, self.option)
+
+        content_grid.attach(icon.get_icon(), 0, 0, 1, 1)
 
         title_label = Gtk.Label()
         title_label.set_line_wrap(True)

--- a/repoman/flatpak.py
+++ b/repoman/flatpak.py
@@ -393,7 +393,7 @@ class Flatpak(Gtk.Box):
         option = self.get_selected_remote(4)
 
         dialog = InfoDialog(self.parent.parent, remote, name, option)
-        response = dialog.run()
+        dialog.run()
         dialog.destroy()
     
     def strip_bold_from_name(self, name):

--- a/repoman/icon.py
+++ b/repoman/icon.py
@@ -1,0 +1,85 @@
+#!/usr/bin/python3
+'''
+   Copyright 2020 Ian Santopietro (ian@system76.com)
+
+   This file is part of Repoman.
+
+    Repoman is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Repoman is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Repoman.  If not, see <http://www.gnu.org/licenses/>.
+'''
+
+import gi
+import logging
+import pathlib
+import urllib
+
+gi.require_versions(
+    {
+        'Gtk': '3.0',
+        'GLib': '2.0',
+        'Gio': '2.0'
+    }
+)
+from gi.repository import Gtk, GLib, GdkPixbuf, Gio
+
+import pyflatpak as flatpak
+
+class RemoteIcon:
+    def __init__(self, remote_name, option):
+        self.remote_data = flatpak.remotes.remotes[option][remote_name]
+        self.remote_name = remote_name
+        self.url = self.remote_data['icon']
+        self.cached = f'/usr/share/repoman/icon-cache/{self.remote_name}.svg'
+        # icon_cache = pathlib.Path('/usr/share/repoman/icon-cache/')
+        # icon_cache.mkdir(parents=True, exist_ok=True)
+    
+    def get_cached(self):
+        
+        stream = Gio.MemoryInputStream.new_from_bytes(
+            GLib.Bytes.new(self.cached)
+        )
+
+        pixbuf = GdkPixbuf.Pixbuf.new_from_stream(stream, None)
+        image = Gtk.Image.new_from_pixbuf(pixbuf)
+        image.set_margin_top(12)
+        image.set_margin_bottom(12)
+
+        return image
+    
+    def get_icon(self):
+        if self.url:
+            with urllib.request.urlopen(self.url) as icon:
+                svgdata = icon.read()
+            
+            stream = Gio.MemoryInputStream.new_from_bytes(
+                GLib.Bytes.new(svgdata)
+            )
+            pixbuf = GdkPixbuf.Pixbuf.new_from_stream_at_scale(
+                stream,
+                64,
+                -1,
+                True,
+                None
+            )
+            image = Gtk.Image.new_from_pixbuf(pixbuf)
+            image.set_margin_top(12)
+            image.set_margin_bottom(12)
+        
+        else:
+            image = Gtk.Image.new_from_icon_name(
+                'notfound',
+                Gtk.IconSize.LARGE_TOOLBAR
+            )
+            image.props.opacity = 0
+
+        return image

--- a/repoman/icon.py
+++ b/repoman/icon.py
@@ -78,7 +78,7 @@ class RemoteIcon:
         else:
             image = Gtk.Image.new_from_icon_name(
                 'notfound',
-                Gtk.IconSize.LARGE_TOOLBAR
+                Gtk.IconSize.SMALL_TOOLBAR
             )
             image.props.opacity = 0
 


### PR DESCRIPTION
Fetch and cache an Icon for each remote, and display it in the UI. If the icon is not available or unspecified, then don't display an icon.