### PR TITLE
Display Errors from APT to the user.

### DIFF
--- a/data/service.py
+++ b/data/service.py
@@ -57,7 +57,7 @@ class PPA(dbus.service.Object):
     
     @dbus.service.method(
         'org.pop_os.repoman.Interface',
-        in_signature='s', out_signature='i',
+        in_signature='s', out_signature='bs',
         sender_keyword='sender', connection_keyword='conn'
     )
     def add_repo(self, line, sender=None, conn=None):
@@ -72,14 +72,14 @@ class PPA(dbus.service.Object):
             self.cache.update()
             self.cache.open(None)
             self.sp.reload_sourceslist()
-            return 0
-        except:
-            self.exc = sys.exc_info()
-            raise RepomanException(self.exc[1])
+            return [True, '']
+        except Exception as e:
+            print(str(e))
+            return [False, str(e)]
     
     @dbus.service.method(
         'org.pop_os.repoman.Interface',
-        in_signature='s', out_signature='i',
+        in_signature='s', out_signature='bs',
         sender_keyword='sender', connection_keyword='conn'
     )
     def delete_repo(self, repo, sender=None, conn=None):
@@ -94,14 +94,14 @@ class PPA(dbus.service.Object):
             self.cache.update()
             self.cache.open(None)
             self.sp.reload_sourceslist()
-            return 0
-        except:
-            self.exc = sys.exc_info()
-            raise RepomanException(self.exc[1])
+            return [True, '']
+        except Exception as e:
+            print(str(e))
+            return [False, str(e)]
 
     @dbus.service.method(
         'org.pop_os.repoman.Interface',
-        in_signature='ss', out_signature='i',
+        in_signature='ss', out_signature='bs',
         sender_keyword='sender', connection_keyword='conn'
     )
     def modify_repo(self, old_repo, new_repo, sender=None, conn=None):
@@ -120,10 +120,10 @@ class PPA(dbus.service.Object):
             self.cache.update()
             self.cache.open(None)
             self.sp.reload_sourceslist()
-            return 0
-        except:
-            self.exc = sys.exc_info()
-            raise RepomanException(self.exc[1])
+            return [True, '']
+        except Exception as e:
+            print(str(e))
+            return [False, str(e)]
     
     @dbus.service.method(
         'org.pop_os.repoman.Interface',

--- a/repoman/ppa.py
+++ b/repoman/ppa.py
@@ -51,16 +51,22 @@ class RemoveThread(threading.Thread):
     def run(self):
         self.log.info( "Removing PPA %s" % (self.ppa) )
         try:
-            privileged_object.delete_repo(self.ppa)
-            self.sp.reload_sourceslist()
-        except dbus.exceptions.DBusException:
-            self.exc = sys.exc_info()
-            self.log.warn(self.exc[1])
-            self.throw_error(f'Could not delete source {str(self.ppa)}')
-        except:
-            self.exc = sys.exc_info()
-            self.log.warn(self.exc[1])
-            self.throw_error(self.exc[1])
+            success, message = privileged_object.delete_repo(self.ppa)
+
+            if not success:
+                self.log.error(message)
+                self.throw_error(message)
+
+        except dbus.exceptions.DBusException as e:
+            if 'PermissionDeniedByPolicy' in e._dbus_error_name:
+                self.throw_error(
+                    'You don\'t have permissions to modify the software sources.'
+                )
+            else:
+                self.throw_error(str(e))
+                raise e
+
+        self.sp.reload_sourceslist()
         isv_list = self.sp.get_isv_sources()
         GObject.idle_add(self.parent.parent.stack.list_all.generate_entries, isv_list)
         GObject.idle_add(self.parent.parent.stack.list_all.view.set_sensitive, True)
@@ -87,16 +93,22 @@ class AddThread(threading.Thread):
         self.log.info("Adding PPA %s" % (self.url))
 
         try:
-            privileged_object.add_repo(self.url)
-            self.sp.reload_sourceslist()
-        except dbus.exceptions.DBusException:
-            self.exc = sys.exc_info()
-            self.log.warn(self.exc[1])
-            self.throw_error(f'Could not add source {self.url}')
-        except:
-            self.exc = sys.exc_info()
-            self.log.warn(self.exc[1])
-            self.throw_error(self.exc[1])
+            success, message = privileged_object.add_repo(self.url)
+
+            if not success:
+                self.log.error(message)
+                self.throw_error(message)
+
+        except dbus.exceptions.DBusException as e:
+            if 'PermissionDeniedByPolicy' in e._dbus_error_name:
+                self.throw_error(
+                    'You don\'t have permissions to modify the software sources.'
+                )
+            else:
+                self.throw_error(str(e))
+                raise e
+
+        self.sp.reload_sourceslist()
         isv_list = self.sp.get_isv_sources()
         GObject.idle_add(self.parent.parent.parent.stack.list_all.generate_entries, isv_list)
         GObject.idle_add(self.parent.parent.parent.stack.list_all.view.set_sensitive, True)
@@ -122,16 +134,24 @@ class ModifyThread(threading.Thread):
 
     def run(self):
         try:
-            privileged_object.modify_repo(self.old_source.__str__(), self.new_source)
-            self.sp.reload_sourceslist()
-        except dbus.exceptions.DBusException:
-            self.exc = sys.exc_info()
-            self.log.warn(self.exc[1])
-            self.throw_error(f'Could not modify source {str(self.old_source)}')
-        except:
-            self.exc = sys.exc_info()
-            self.log.warn(self.exc[1])
-            self.throw_error(self.exc[1])
+            success, message = privileged_object.modify_repo(
+                self.old_source.__str__(), self.new_source
+            )
+
+            if not success:
+                self.log.error(message)
+                self.throw_error(message)
+
+        except dbus.exceptions.DBusException as e:
+            if 'PermissionDeniedByPolicy' in e._dbus_error_name:
+                self.throw_error(
+                    'You don\'t have permissions to modify the software sources.'
+                )
+            else:
+                self.throw_error(str(e))
+                raise e
+
+        self.sp.reload_sourceslist()
         isv_list = self.sp.get_isv_sources()
         GObject.idle_add(self.parent.parent.parent.stack.list_all.generate_entries, isv_list)
         GObject.idle_add(self.parent.parent.parent.stack.list_all.view.set_sensitive, True)


### PR DESCRIPTION
We do this by returning an array [bool, str] from the DBus service. If the modification
is successful, then the array is [True, '']. However, if the modification fails, the
array is [False, error_message], which can then be checked and displayed in the GUI.

fixes #37