### PR TITLE
Disable buttons without row

### DIFF
--- a/repoman/flatpak.py
+++ b/repoman/flatpak.py
@@ -263,13 +263,11 @@ class Flatpak(Gtk.Box):
 
         self.remote_liststore = Gtk.ListStore(str, str, str, str, str)
         self.view = Gtk.TreeView(self.remote_liststore)
-        self.view.connect('cursor-changed', self.on_view_cursor_change)
         
         name_renderer = Gtk.CellRendererText()
         name_renderer.props.wrap_mode = Pango.WrapMode.WORD_CHAR
         name_renderer.props.wrap_width = 120
         name_column = Gtk.TreeViewColumn(_('Source'), name_renderer, markup=1)
-        # name_column.set_resizable(True)
         self.view.append_column(name_column)
 
         url_renderer = Gtk.CellRendererText()
@@ -284,8 +282,8 @@ class Flatpak(Gtk.Box):
 
         self.view.set_hexpand(True)
         self.view.set_vexpand(True)
-        tree_selection = self.view.get_selection()
-        tree_selection.connect('changed', self.on_row_change)
+        self.tree_selection = self.view.get_selection()
+        self.tree_selection.connect('changed', self.on_row_selected)
         list_window.add(self.view)
 
         # add button
@@ -449,21 +447,15 @@ class Flatpak(Gtk.Box):
             )
         self.add_button.set_sensitive(True)
 
-    def on_row_change(self, widget):
+    def on_row_selected(self, widget):
         (model, pathlist) = widget.get_selected_rows()
         if pathlist:
+            self.info_button.set_sensitive(True)
+            self.delete_button.set_sensitive(True)
             for path in pathlist :
                 tree_iter = model.get_iter(path)
                 value = model.get_value(tree_iter,1)
                 self.remote_name = value
-    
-    def on_view_cursor_change(self, widget, data=None):
-        model, pathlist = self.view.get_selection().get_selected_rows()
-        self.log.debug('View change; get_selection=%s', pathlist)
-
-        if pathlist:
-            self.info_button.set_sensitive(True)
-            self.delete_button.set_sensitive(True)
         else:
             self.info_button.set_sensitive(False)
             self.delete_button.set_sensitive(False)

--- a/repoman/flatpak.py
+++ b/repoman/flatpak.py
@@ -263,6 +263,7 @@ class Flatpak(Gtk.Box):
 
         self.remote_liststore = Gtk.ListStore(str, str, str, str, str)
         self.view = Gtk.TreeView(self.remote_liststore)
+        self.view.connect('cursor-changed', self.on_view_cursor_change)
         
         name_renderer = Gtk.CellRendererText()
         name_renderer.props.wrap_mode = Pango.WrapMode.WORD_CHAR
@@ -288,36 +289,39 @@ class Flatpak(Gtk.Box):
         list_window.add(self.view)
 
         # add button
-        add_button = Gtk.ToolButton()
-        add_button.set_icon_name("list-add-symbolic")
-        Gtk.StyleContext.add_class(add_button.get_style_context(),
+        self.add_button = Gtk.ToolButton()
+        self.add_button.set_sensitive(False)
+        self.add_button.set_icon_name("list-add-symbolic")
+        Gtk.StyleContext.add_class(self.add_button.get_style_context(),
                                    "image-button")
-        add_button.set_tooltip_text(_("Add New Source"))
-        add_button.connect("clicked", self.on_add_button_clicked)
+        self.add_button.set_tooltip_text(_("Add New Source"))
+        self.add_button.connect("clicked", self.on_add_button_clicked)
 
         # info button
-        info_button = Gtk.ToolButton()
-        info_button.set_icon_name('help-info-symbolic')
-        Gtk.StyleContext.add_class(add_button.get_style_context(),
+        self.info_button = Gtk.ToolButton()
+        self.info_button.set_sensitive(False)
+        self.info_button.set_icon_name('help-info-symbolic')
+        Gtk.StyleContext.add_class(self.add_button.get_style_context(),
                                    "image-button")
-        info_button.set_tooltip_text(_('Remote Info'))
-        info_button.connect('clicked', self.on_info_button_clicked)
+        self.info_button.set_tooltip_text(_('Remote Info'))
+        self.info_button.connect('clicked', self.on_info_button_clicked)
 
         # delete button
-        delete_button = Gtk.ToolButton()
-        delete_button.set_icon_name("edit-delete-symbolic")
-        Gtk.StyleContext.add_class(delete_button.get_style_context(),
+        self.delete_button = Gtk.ToolButton()
+        self.delete_button.set_sensitive(False)
+        self.delete_button.set_icon_name("edit-delete-symbolic")
+        Gtk.StyleContext.add_class(self.delete_button.get_style_context(),
                                    "image-button")
-        delete_button.set_tooltip_text(_("Remove Selected Source"))
-        delete_button.connect("clicked", self.on_delete_button_clicked)
+        self.delete_button.set_tooltip_text(_("Remove Selected Source"))
+        self.delete_button.connect("clicked", self.on_delete_button_clicked)
 
         action_bar = Gtk.Toolbar()
         action_bar.set_icon_size(Gtk.IconSize.SMALL_TOOLBAR)
         Gtk.StyleContext.add_class(action_bar.get_style_context(),
                                    "inline-toolbar")
-        action_bar.insert(delete_button, 0)
-        action_bar.insert(info_button, 0)
-        action_bar.insert(add_button, 0)
+        action_bar.insert(self.delete_button, 0)
+        action_bar.insert(self.info_button, 0)
+        action_bar.insert(self.add_button, 0)
         list_grid.attach(action_bar, 0, 1, 1, 1)
 
         self.generate_entries()
@@ -331,6 +335,9 @@ class Flatpak(Gtk.Box):
         response = dialog.run()
         
         if response == Gtk.ResponseType.OK:
+            self.add_button.set_sensitive(False)
+            self.info_button.set_sensitive(False)
+            self.delete_button.set_sensitive(False)
             try:
                 flatpak.remotes.delete_remote(remote)
             except DeleteRemoteError:
@@ -393,6 +400,9 @@ class Flatpak(Gtk.Box):
         self.log.debug('Response type: %s', response)
 
         if response == Gtk.ResponseType.OK:
+            self.add_button.set_sensitive(False)
+            self.info_button.set_sensitive(False)
+            self.delete_button.set_sensitive(False)
             url = dialog.url_entry.get_text().strip()
             name = splitext(url.split('/')[-1])[0]
             self.log.info('Adding flatpak source %s at %s', name, url)
@@ -437,13 +447,26 @@ class Flatpak(Gtk.Box):
                     remotes[remote]["option"]
                 ]
             )
+        self.add_button.set_sensitive(True)
 
     def on_row_change(self, widget):
         (model, pathlist) = widget.get_selected_rows()
-        for path in pathlist :
-            tree_iter = model.get_iter(path)
-            value = model.get_value(tree_iter,1)
-            self.remote_name = value
+        if pathlist:
+            for path in pathlist :
+                tree_iter = model.get_iter(path)
+                value = model.get_value(tree_iter,1)
+                self.remote_name = value
+    
+    def on_view_cursor_change(self, widget, data=None):
+        model, pathlist = self.view.get_selection().get_selected_rows()
+        self.log.debug('View change; get_selection=%s', pathlist)
+
+        if pathlist:
+            self.info_button.set_sensitive(True)
+            self.delete_button.set_sensitive(True)
+        else:
+            self.info_button.set_sensitive(False)
+            self.delete_button.set_sensitive(False)
 
     def throw_error_dialog(self, message, msg_type):
         if msg_type == "error":

--- a/repoman/list.py
+++ b/repoman/list.py
@@ -84,39 +84,43 @@ class List(Gtk.Box):
         self.view.set_vexpand(True)
         tree_selection = self.view.get_selection()
         tree_selection.connect('changed', self.on_row_change)
+        self.view.connect('cursor-changed', self.on_view_cursor_change)
         list_window.add(self.view)
 
         # add button
-        add_button = Gtk.ToolButton()
-        add_button.set_icon_name("list-add-symbolic")
-        Gtk.StyleContext.add_class(add_button.get_style_context(),
+        self.add_button = Gtk.ToolButton()
+        self.add_button.set_sensitive(False)
+        self.add_button.set_icon_name("list-add-symbolic")
+        Gtk.StyleContext.add_class(self.add_button.get_style_context(),
                                    "image-button")
-        add_button.set_tooltip_text(_("Add New Source"))
-        add_button.connect("clicked", self.on_add_button_clicked)
+        self.add_button.set_tooltip_text(_("Add New Source"))
+        self.add_button.connect("clicked", self.on_add_button_clicked)
 
         # edit button
-        edit_button = Gtk.ToolButton()
-        edit_button.set_icon_name("edit-symbolic")
-        Gtk.StyleContext.add_class(edit_button.get_style_context(),
+        self.edit_button = Gtk.ToolButton()
+        self.edit_button.set_sensitive(False)
+        self.edit_button.set_icon_name("edit-symbolic")
+        Gtk.StyleContext.add_class(self.edit_button.get_style_context(),
                                    "image-button")
-        edit_button.set_tooltip_text(_("Modify Selected Source"))
-        edit_button.connect("clicked", self.on_edit_button_clicked)
+        self.edit_button.set_tooltip_text(_("Modify Selected Source"))
+        self.edit_button.connect("clicked", self.on_edit_button_clicked)
 
         # delete button
-        delete_button = Gtk.ToolButton()
-        delete_button.set_icon_name("edit-delete-symbolic")
-        Gtk.StyleContext.add_class(delete_button.get_style_context(),
+        self.delete_button = Gtk.ToolButton()
+        self.delete_button.set_sensitive(False)
+        self.delete_button.set_icon_name("edit-delete-symbolic")
+        Gtk.StyleContext.add_class(self.delete_button.get_style_context(),
                                    "image-button")
-        delete_button.set_tooltip_text(_("Modify Selected Source"))
-        delete_button.connect("clicked", self.on_delete_button_clicked)
+        self.delete_button.set_tooltip_text(_("Modify Selected Source"))
+        self.delete_button.connect("clicked", self.on_delete_button_clicked)
 
         action_bar = Gtk.Toolbar()
         action_bar.set_icon_size(Gtk.IconSize.SMALL_TOOLBAR)
         Gtk.StyleContext.add_class(action_bar.get_style_context(),
                                    "inline-toolbar")
-        action_bar.insert(delete_button, 0)
-        action_bar.insert(edit_button, 0)
-        action_bar.insert(add_button, 0)
+        action_bar.insert(self.delete_button, 0)
+        action_bar.insert(self.edit_button, 0)
+        action_bar.insert(self.add_button, 0)
         list_grid.attach(action_bar, 0, 1, 1, 1)
 
         self.generate_entries(self.ppa.get_isv())
@@ -134,6 +138,9 @@ class List(Gtk.Box):
         response = dialog.run()
 
         if response == Gtk.ResponseType.OK:
+            self.add_button.set_sensitive(False)
+            self.edit_button.set_sensitive(False)
+            self.delete_button.set_sensitive(False)
             self.ppa.remove(repo)
             dialog.destroy()
         
@@ -167,6 +174,9 @@ class List(Gtk.Box):
         response = dialog.run()
 
         if response == Gtk.ResponseType.OK:
+            self.add_button.set_sensitive(False)
+            self.edit_button.set_sensitive(False)
+            self.delete_button.set_sensitive(False)
             if dialog.type_box.get_active() == 0:
                 new_rtype = "deb"
             elif dialog.type_box.get_active() == 1:
@@ -197,6 +207,9 @@ class List(Gtk.Box):
         response = dialog.run()
 
         if response == Gtk.ResponseType.OK:
+            self.add_button.set_sensitive(False)
+            self.edit_button.set_sensitive(False)
+            self.delete_button.set_sensitive(False)
             url = dialog.ppa_entry.get_text()
             dialog.destroy()
             self.ppa.add(url)
@@ -228,13 +241,26 @@ class List(Gtk.Box):
                     self.ppa_liststore.insert_with_valuesv(-1,
                                                            [0, 1],
                                                            [source_pretty, str(source)])
+        self.add_button.set_sensitive(True)
 
     def on_row_change(self, widget):
         (model, pathlist) = widget.get_selected_rows()
-        for path in pathlist :
-            tree_iter = model.get_iter(path)
-            value = model.get_value(tree_iter,1)
-            self.ppa_name = value
+        if pathlist:
+            for path in pathlist :
+                tree_iter = model.get_iter(path)
+                value = model.get_value(tree_iter,1)
+                self.ppa_name = value
+    
+    def on_view_cursor_change(self, widget, data=None):
+        model, pathlist = self.view.get_selection().get_selected_rows()
+        self.log.debug('View change; get_selection=%s', pathlist)
+
+        if pathlist:
+            self.edit_button.set_sensitive(True)
+            self.delete_button.set_sensitive(True)
+        else:
+            self.edit_button.set_sensitive(False)
+            self.delete_button.set_sensitive(False)
 
     def throw_error_dialog(self, message, msg_type):
         dialog = ErrorDialog(

--- a/repoman/list.py
+++ b/repoman/list.py
@@ -82,9 +82,8 @@ class List(Gtk.Box):
         self.view.append_column(column)
         self.view.set_hexpand(True)
         self.view.set_vexpand(True)
-        tree_selection = self.view.get_selection()
-        tree_selection.connect('changed', self.on_row_change)
-        self.view.connect('cursor-changed', self.on_view_cursor_change)
+        self.tree_selection = self.view.get_selection()
+        self.tree_selection.connect('changed', self.on_row_selected)
         list_window.add(self.view)
 
         # add button
@@ -243,21 +242,15 @@ class List(Gtk.Box):
                                                            [source_pretty, str(source)])
         self.add_button.set_sensitive(True)
 
-    def on_row_change(self, widget):
+    def on_row_selected(self, widget):
         (model, pathlist) = widget.get_selected_rows()
-        if pathlist:
-            for path in pathlist :
-                tree_iter = model.get_iter(path)
-                value = model.get_value(tree_iter,1)
-                self.ppa_name = value
-    
-    def on_view_cursor_change(self, widget, data=None):
-        model, pathlist = self.view.get_selection().get_selected_rows()
-        self.log.debug('View change; get_selection=%s', pathlist)
-
         if pathlist:
             self.edit_button.set_sensitive(True)
             self.delete_button.set_sensitive(True)
+            for path in pathlist :
+                tree_iter = model.get_iter(path)
+                value = model.get_value(tree_iter,1)
+                self.remote_name = value
         else:
             self.edit_button.set_sensitive(False)
             self.delete_button.set_sensitive(False)


### PR DESCRIPTION
This disables the list buttons in the Apt and Flatpak pages when there isn't a row selected, which prevents them from being clicked with nothing happening, and generating the error messages from #49. They should be enabled when a row is selected, and be disabled again when a row is deselected. 

This also disables the Add buttons when there is an operation pending, so that we don't cause problems from the user clicking these during the middle of a package operation. The button is enabled again once the operation is finished and the list is regenerated.

fixes #49 