### PR TITLE
Replace Pyflatpak with PyGObject Flatpak

### DIFF
--- a/.cz.toml
+++ b/.cz.toml
@@ -1,0 +1,8 @@
+# This defines our version tracking
+[tool.commitizen]
+name = "cz_conventional_commits"
+version = "1.2.0"
+tag_format = "v$version"
+version_files = [
+    'setup.py:version'
+]

--- a/.cz.toml
+++ b/.cz.toml
@@ -1,7 +1,7 @@
 # This defines our version tracking
 [tool.commitizen]
 name = "cz_conventional_commits"
-version = "1.2.0"
+version = "1.2.1"
 tag_format = "v$version"
 version_files = [
     'setup.py:version'

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,15 @@
+## Basic Contribution Guidelines
+
+Please make sure to follow good version control practices. Use branches to track
+individual features, and try to limit to one feature per branch. Use `git rebase`
+to update your branch with the latest copy of master before submitting a PR. 
+
+
+### Commits
+
+Use commits to track individual changes, and branches to track features. Using 
+[`cz`](https://github.com/Woile/commitizen/) to make commits and bump versions
+is a good idea, and remember to follow 
+[Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
+guidelines. PRs containing non-forming commits may be rejected until they are
+modified to work more correctly with these guidelines.

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,9 +1,13 @@
-repoman (1.1.0) UNRELEASED; urgency=medium
+repoman (1.2.0) eoan; urgency=medium
 
+  [ Ian Santopietro ]
   * Switching to PolicyKit to handle permissions on-demand, avoiding
     the need to run the GUI as root.
 
- -- Ian Santopietro <ian@akira.local>  Tue, 19 Nov 2019 14:40:02 -0700
+  [ Ian Santopiero ]
+  * Adding Flatpak Support for managing flatpak remotes.
+
+ -- Ian Santopiero <ian@system76.com>  Wed, 12 Feb 2020 10:02:40 -0700
 
 repoman (1.0.2) bionic; urgency=medium
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,10 +1,7 @@
 repoman (1.2.0) eoan; urgency=medium
 
-  [ Ian Santopietro ]
   * Switching to PolicyKit to handle permissions on-demand, avoiding
     the need to run the GUI as root.
-
-  [ Ian Santopiero ]
   * Adding Flatpak Support for managing flatpak remotes.
 
  -- Ian Santopiero <ian@system76.com>  Wed, 12 Feb 2020 10:02:40 -0700

--- a/debian/control
+++ b/debian/control
@@ -7,6 +7,7 @@ Build-Depends: debhelper (>= 10),
                python3-all,
                software-properties-common,
                gir1.2-gtk-3.0,
+               libflatpak-dev,
 Standards-Version: 3.9.3
 X-Python3-Version: >= 3.4
 

--- a/repoman/flatpak.py
+++ b/repoman/flatpak.py
@@ -305,7 +305,9 @@ class Flatpak(Gtk.Box):
         list_grid = Gtk.Grid()
         self.content_grid.attach(list_grid, 0, 2, 1, 1)
         list_window = Gtk.ScrolledWindow()
-        Gtk.StyleContext.add_class(list_window.get_style_context(), "list_window")
+        Gtk.StyleContext.add_class(
+            list_window.get_style_context(), "list_window"
+        )
         list_grid.attach(list_window, 0, 0, 1, 1)
 
         self.remote_liststore = Gtk.ListStore(str, str, str, str, str)
@@ -413,7 +415,9 @@ class Flatpak(Gtk.Box):
             self.delete_button.set_sensitive(False)
             self.view.set_sensitive(False)
             
-            remove_thread = RemoveThread(self, remote, removed_refs, installation)
+            remove_thread = RemoveThread(
+                self, remote, removed_refs, installation
+            )
             remove_thread.start()
         else:
             dialog.destroy()

--- a/repoman/stack.py
+++ b/repoman/stack.py
@@ -27,7 +27,7 @@ from .updates import Updates
 from .list import List
 try:
     from .flatpak import Flatpak
-except ImportError:
+except (ImportError, ValueError):
     Flatpak = False
 import gettext
 gettext.bindtextdomain('repoman', '/usr/share/repoman/po')

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ import sys
 
 setup(
     name = 'repoman',
-    version = '1.1.0',
+    version = '1.2.0',
     description = 'Easily manage software sources',
     url = 'https://github.com/pop-os/repoman',
     license = 'GNU GPL3',

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ import sys
 
 setup(
     name = 'repoman',
-    version = '1.2.0',
+    version = '1.2.1',
     description = 'Easily manage software sources',
     url = 'https://github.com/pop-os/repoman',
     license = 'GNU GPL3',


### PR DESCRIPTION
When we started work on flatpak for Repoman, it wasn't known that PyGObject had bindings for libflatpak. Recently it was discovered that that was the case, and since that is an official Flatpak library, we should use that instead of pyflatpak.