### PR TITLE
fix(dialog): Fix imports on systems without Flatpak

### DIFF
--- a/repoman/dialog.py
+++ b/repoman/dialog.py
@@ -28,7 +28,10 @@ gettext.bindtextdomain('repoman', '/usr/share/repoman/po')
 gettext.textdomain("repoman")
 _ = gettext.gettext
 
-from . import flatpak_helper 
+try:
+    from . import flatpak_helper 
+except (ImportError, ValueError):
+    pass
 from .ppa import PPA
 
 class ErrorDialog(Gtk.Dialog):


### PR DESCRIPTION
When dialogs were consolidated into a single class, it was required to perform some minor flatpak tasks from within the dialog module. However, this must be done conditionally and be allowed to fail without problems, as the dialog module is also used with non-flatpak parts of the code.

Fixes #60