### PR TITLE
1.2.2 - Remove python-requests from dependencies

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+repoman (1.2.2) bionic; urgency=medium
+
+  * Remove python-requests from dependencies
+
+ -- Jeremy Soller <jeremy@system76.com>  Fri, 24 Apr 2020 15:28:40 -0600
+
 repoman (1.2.1) eoan; urgency=medium
 
   * Refactor for easier development and better performance

--- a/debian/control
+++ b/debian/control
@@ -16,7 +16,6 @@ Architecture: all
 Depends: ${python3:Depends}, ${misc:Depends},
          software-properties-common,
          gir1.2-gtk-3.0,
-         python-requests,
 Description: Repoman
  Hey man, let's go do crimes. Yeah, let's install software and not pay.
 

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ import sys
 
 setup(
     name = 'repoman',
-    version = '1.2.1',
+    version = '1.2.2',
     description = 'Easily manage software sources',
     url = 'https://github.com/pop-os/repoman',
     license = 'GNU GPL3',


### PR DESCRIPTION
Rebase and tag when approved. Required for building 20.04 ISOs