### PR TITLE
Fix delete button tooltip and fix a typo.

### DIFF
--- a/repoman/list.py
+++ b/repoman/list.py
@@ -61,7 +61,7 @@ class List(Gtk.Box):
         Gtk.StyleContext.add_class(sources_title.get_style_context(), "h2")
         self.content_grid.attach(sources_title, 0, 0, 1, 1)
 
-        sources_label = Gtk.Label(_("These sources are for software provided by a third party. They may present a security risk or can cause system instability. Only add sources that you trust."))
+        sources_label = Gtk.Label(_("These sources are for software provided by a third party. They may present a security risk or cause system instability. Only add sources that you trust."))
         sources_label.set_line_wrap(True)
         sources_label.set_justify(Gtk.Justification.FILL)
         sources_label.set_halign(Gtk.Align.START)
@@ -109,7 +109,7 @@ class List(Gtk.Box):
         self.delete_button.set_icon_name("edit-delete-symbolic")
         Gtk.StyleContext.add_class(self.delete_button.get_style_context(),
                                    "image-button")
-        self.delete_button.set_tooltip_text(_("Modify Selected Source"))
+        self.delete_button.set_tooltip_text(_("Delete Selected Source"))
         self.delete_button.connect("clicked", self.on_delete_button_clicked)
 
         action_bar = Gtk.Toolbar()

--- a/repoman/settings.py
+++ b/repoman/settings.py
@@ -60,7 +60,7 @@ class Settings(Gtk.Box):
         Gtk.StyleContext.add_class(sources_title.get_style_context(), "h2")
         settings_grid.attach(sources_title, 0, 0, 1, 1)
 
-        sources_label = Gtk.Label(_("Official sources are those provided by %s and its developers. It's recommended to leave these sources enabled.") % self.os_name)
+        sources_label = Gtk.Label(_("Official sources are provided by %s and its developers. It's recommended to leave these sources enabled.") % self.os_name)
         sources_label.set_line_wrap(True)
         sources_label.set_justify(Gtk.Justification.FILL)
         sources_label.set_halign(Gtk.Align.START)
@@ -87,7 +87,7 @@ class Settings(Gtk.Box):
         self.developer_grid.set_spacing(12)
         developer_options.add(self.developer_grid)
 
-        developer_label = Gtk.Label(_("These options are those which are primarily of interest to developers."))
+        developer_label = Gtk.Label(_("These options are primarily of interest to developers."))
         developer_label.set_line_wrap(True)
         developer_label.set_halign(Gtk.Align.START)
         developer_label.set_margin_start(5)


### PR DESCRIPTION
The "delete" button's tooltip still said "Modify Selected Source". While a deletion is a modification, we probably want to be more specific.

Also removed the word "can" in the description that already had "may" as a qualifier.