### PR TITLE
Reset checkmarks

### DIFF
--- a/repoman/ppa.py
+++ b/repoman/ppa.py
@@ -182,21 +182,25 @@ class PPA:
 
     # Returns the current distro Components.
     def get_distro_sources(self):
+        self.sp.reload_sourceslist()
         components = self.sp.distro.source_template.components
         return components
 
     # Returns the current child repos (updates)
     def get_distro_child_repos(self):
+        self.sp.reload_sourceslist()
         repos = self.sp.distro.source_template.children
         return repos
 
     # Get whether a component is enabled or not
     def get_comp_download_state(self, comp):
+        self.sp.reload_sourceslist()
         (active, inconsistent) = self.sp.get_comp_download_state(comp)
         return (active, inconsistent)
 
     # Get whether a child repo is enabled or not
     def get_child_download_state(self, child):
+        self.sp.reload_sourceslist()
         (active, inconsistent) = self.sp.get_comp_child_state(child)
         self.log.debug(child.name + " (" + str(active) + ", " + str(inconsistent) + ")")
         return (active, inconsistent)

--- a/repoman/settings.py
+++ b/repoman/settings.py
@@ -179,6 +179,10 @@ class Settings(Gtk.Box):
             self.ppa.set_comp_enabled(comp, enabled)
         except dbus.exceptions.DBusException:
             self.show_distro()
+        
+        self.parent.updates.init_updates()
+        self.parent.updates.show_updates()
+
         return 0
 
     def on_source_check_toggled(self, checkbutton):
@@ -187,6 +191,10 @@ class Settings(Gtk.Box):
             self.ppa.set_source_code_enabled(enabled)
         except dbus.exceptions.DBusException:
             self.show_distro()
+        
+        self.parent.updates.init_updates()
+        self.parent.updates.show_updates()
+
         return 0
 
     def on_proposed_check_toggled(self, checkbutton, comp):
@@ -195,5 +203,9 @@ class Settings(Gtk.Box):
             self.ppa.set_child_enabled(comp.name, enabled)
         except dbus.exceptions.DBusException:
             self.show_distro()
+        
+        self.parent.updates.init_updates()
+        self.parent.updates.show_updates()
+
         return 0
     

--- a/repoman/settings.py
+++ b/repoman/settings.py
@@ -163,6 +163,16 @@ class Settings(Gtk.Box):
                                                    template)
 
         return 0
+    
+    def show_source_code(self):
+        (active, inconsistent) = self.ppa.get_source_code_enabled()
+        self.source_check.set_active(active)
+        self.source_check.set_inconsistent(inconsistent)
+    
+    def show_proposed(self):
+        (active, inconsistent) = self.ppa.get_child_download_state(self.proposed_check.template)
+        self.proposed_check.set_active(active)
+        self.proposed_check.set_inconsistent(inconsistent)
 
     def show_distro(self):
         self.block_handlers()
@@ -172,14 +182,8 @@ class Settings(Gtk.Box):
             checkbox.set_active(active)
             checkbox.set_inconsistent(inconsistent)
 
-        (src_active, src_inconsistent) = self.ppa.get_source_code_enabled()
-        self.source_check.set_active(src_active)
-        self.source_check.set_inconsistent(src_inconsistent)
-
-        (prop_active, prop_inconsistent) = self.ppa.get_child_download_state(self.proposed_check.template)
-        self.proposed_check.set_active(prop_active)
-        self.proposed_check.set_inconsistent(prop_inconsistent)
-
+        self.show_proposed()
+        self.show_source_code()
         self.unblock_handlers()
         self.prev_enabled = self.checks_enabled
         return 0
@@ -191,9 +195,10 @@ class Settings(Gtk.Box):
         except dbus.exceptions.DBusException:
             self.show_distro()
         
-        if self.checks_enabled != self.prev_enabled:
-            self.parent.updates.init_updates()
+        if self.checks_enabled != self.prev_enabled and self.prev_enabled:
             self.parent.updates.show_updates()
+            self.show_proposed()
+            self.show_source_code()
         
         self.prev_enabled = self.checks_enabled
         return 0

--- a/repoman/settings.py
+++ b/repoman/settings.py
@@ -164,6 +164,15 @@ class Settings(Gtk.Box):
 
         return 0
     
+    def set_child_checks_sensitive(self):
+        self.source_check.set_sensitive(self.prev_enabled)
+        self.proposed_check.set_sensitive(self.prev_enabled)
+        try:
+            self.parent.updates.set_checks_enabled(self.prev_enabled)
+        except AttributeError:
+            # In case the updates page hasn't been init'd yet
+            pass
+    
     def show_source_code(self):
         (active, inconsistent) = self.ppa.get_source_code_enabled()
         self.source_check.set_active(active)
@@ -186,6 +195,7 @@ class Settings(Gtk.Box):
         self.show_source_code()
         self.unblock_handlers()
         self.prev_enabled = self.checks_enabled
+        self.set_child_checks_sensitive()
         return 0
 
     def on_component_toggled(self, checkbutton, comp):
@@ -201,6 +211,7 @@ class Settings(Gtk.Box):
             self.show_source_code()
         
         self.prev_enabled = self.checks_enabled
+        self.set_child_checks_sensitive()
         return 0
 
     def on_source_check_toggled(self, checkbutton):

--- a/repoman/settings.py
+++ b/repoman/settings.py
@@ -98,6 +98,10 @@ class Settings(Gtk.Box):
 
         self.init_distro()
         self.show_distro()
+        self.block_handlers()
+        self.show_proposed()
+        self.show_source_code()
+        self.unblock_handlers()
 
     @property
     def checks_enabled(self):
@@ -191,8 +195,6 @@ class Settings(Gtk.Box):
             checkbox.set_active(active)
             checkbox.set_inconsistent(inconsistent)
 
-        self.show_proposed()
-        self.show_source_code()
         self.unblock_handlers()
         self.prev_enabled = self.checks_enabled
         self.set_child_checks_sensitive()
@@ -209,6 +211,9 @@ class Settings(Gtk.Box):
             self.parent.updates.show_updates()
             self.show_proposed()
             self.show_source_code()
+        
+        if 'multiverse' in checkbutton.get_label():
+            self.show_distro()
         
         self.prev_enabled = self.checks_enabled
         self.set_child_checks_sensitive()

--- a/repoman/stack.py
+++ b/repoman/stack.py
@@ -45,14 +45,17 @@ class Stack(Gtk.Box):
         self.stack.set_transition_duration(300)
 
         self.setting = Settings(self)
+        self.stack.add_titled(self.setting, "settings", _("Settings"))
+        
         self.updates = Updates(self)
+        self.stack.add_titled(self.updates, "updates", _("Updates"))
+        
         self.list_all = List(self)
+        self.stack.add_titled(self.list_all, "list", _("Extra Sources"))
+        
         if Flatpak:
             self.flatpak = Flatpak(self)
 
-        self.stack.add_titled(self.setting, "settings", _("Settings"))
-        self.stack.add_titled(self.updates, "updates", _("Updates"))
-        self.stack.add_titled(self.list_all, "list", _("Extra Sources"))
         if Flatpak:
             self.stack.add_titled(self.flatpak, "flatpak", _("Flatpak"))
 

--- a/repoman/updates.py
+++ b/repoman/updates.py
@@ -107,6 +107,7 @@ class Updates(Gtk.Box):
 
         self.init_updates()
         self.show_updates()
+        self.set_checks_enabled(self.parent.setting.checks_enabled)
 
     def block_handlers(self):
         for widget in self.handlers:
@@ -147,6 +148,10 @@ class Updates(Gtk.Box):
             self.checks_grid.add(checkbox)
             checkbox.show()
         return 0
+    
+    def set_checks_enabled(self, enabled):
+        for checkbox in self.checks_grid.get_children():
+            checkbox.set_sensitive(enabled)
 
     def show_updates(self):
         self.block_handlers()

--- a/repoman/updates.py
+++ b/repoman/updates.py
@@ -165,4 +165,3 @@ class Updates(Gtk.Box):
             self.ppa.set_child_enabled(child.name, enabled)
         except dbus.exceptions.DBusException:
             self.show_updates()
-


### PR DESCRIPTION
Resets the checkboxes on the Updates page when changes are made to the checks on the Settings page. This is required because the settings pages enable or disable components (`main`, `universe`, etc.) but the Updates tab adds or removes lines. If all components are disabled, the Updates page loses sync with the actual state of the sources.list file.

With this change, if all items are unchecked in the settings page, the checkboxes in the updates page will end up disabled too, matching the state of the sources.list file. When components are enabled again, these remain unchecked (which matches the behavior in the Ubuntu `software-properties-gtk` package.

Fixes #70