### PR TITLE
fix(repo): use repolib get_all_sources() method to fetch sources

### DIFF
--- a/repoman/list.py
+++ b/repoman/list.py
@@ -138,8 +138,9 @@ class List(Gtk.Box):
         (model, pathlist) = selec.get_selected_rows()
         tree_iter = model.get_iter(pathlist[0])
         repo_name = model.get_value(tree_iter, 2)
-        self.log.debug('Deleting PPA: %s', repo_name)
-        self.do_delete(repo_name)
+        repo = self.sources[repo_name]
+        self.log.debug('Deleting PPA: %s', repo.filename)
+        self.do_delete(repo.filename)
     
     def do_delete(self, repo_name):
         dialog = DeleteDialog(self.parent.parent, 'Source')

--- a/repoman/list.py
+++ b/repoman/list.py
@@ -218,7 +218,7 @@ class List(Gtk.Box):
                     self.ppa_liststore.insert_with_valuesv(
                         -1,
                         [0, 1, 2],
-                        [f'<b>{source.name}</b>', source.uris[0], source.filename]
+                        [f'<b>{source.name}</b>', source.uris[0], source.ident]
                     )
             except AttributeError:
                 # Skip any weirdly malformed sources
@@ -231,7 +231,7 @@ class List(Gtk.Box):
                     self.ppa_liststore.insert_with_valuesv(
                         -1,
                         [0, 1, 2],
-                        [source.name, source.uris[0], source.filename]
+                        [source.name, source.uris[0], source.ident]
                     )
             except AttributeError:
                 pass

--- a/repoman/repo.py
+++ b/repoman/repo.py
@@ -125,37 +125,16 @@ def get_all_sources(get_system=False):
         The above described dict.
     """
     sources = {}
-
-    if get_system:
-        try:
-            system = get_repo_for_name('system')
-            sources['system'] = system
-        except Exception:
-            pass
     sources_dir = repolib.util.get_sources_dir()
-    sources_files = sources_dir.glob('*.sources')
-    list_files = sources_dir.glob('*.list')
     try:
         sources_list_file = sources_dir.parent / 'sources.list'
     except FileNotFoundError:
         sources_list_file = None
     
-    log.debug('Loading .sources files')
-    for file in sources_files:
-        if file.name == 'system.sources':
-            # We loaded system before (or didn't because we aren't supposed to)
-            continue
-        log.debug('Loading %s', file)
-        source = repolib.Source(filename=file.name)
-        source.load_from_file()
-        sources[source.filename] = source
-    
-    log.debug('Loading .list files')
-    for file in list_files:
-        log.debug('Loading %s', file)
-        source = repolib.LegacyDebSource(filename=file.name)
-        source.load_from_file()
-        sources[source.filename] = source
+    sources_list = repolib.get_all_sources(get_system=get_system)
+
+    for source in sources_list:
+        sources[source.ident] = source
     
     if sources_list_file:
         sources['sources.list'] = {}


### PR DESCRIPTION
This is better than doing it manually because we weren't catching errors, leading to repoman crashing on startup if there was an invalid source. Now it will skip the invalid sources instead of crashing

This will help ensure that even if there are invalid sources on the system Repoman will launch without the invalid sources (while the rest of the sources will be available).

It also sets us up for the better error handling in Repolib coming shortly.