### PR TITLE
Show error dialogs when sources have errors

### DIFF
--- a/repoman/dialog.py
+++ b/repoman/dialog.py
@@ -34,12 +34,13 @@ except (ImportError, ValueError):
     pass
 from . import repo
 
+settings = Gtk.Settings.get_default()
+header = settings.props.gtk_dialogs_use_header
+
 class ErrorDialog(Gtk.Dialog):
 
     def __init__(self, parent, dialog_title, dialog_icon,
                  message_title, message_text):
-        settings = Gtk.Settings.get_default()
-        header = settings.props.gtk_dialogs_use_header
                  
         super().__init__(use_header_bar=header, modal=1)
         self.set_deletable(False)
@@ -77,10 +78,6 @@ class AddDialog(Gtk.Dialog):
     ppa_name = False
 
     def __init__(self, parent, flatpak=False):
-
-        settings = Gtk.Settings.get_default()
-        header = settings.props.gtk_dialogs_use_header
-
         Gtk.Dialog.__init__(self, _("Add Source"), parent, 0,
                             (Gtk.STOCK_CANCEL, Gtk.ResponseType.CANCEL,
                              Gtk.STOCK_ADD, Gtk.ResponseType.OK),
@@ -169,10 +166,6 @@ class DeleteDialog(Gtk.Dialog):
     ppa_name = False
 
     def __init__(self, parent, title, flatpak=False, refs=None):
-
-        settings = Gtk.Settings.get_default()
-        header = settings.props.gtk_dialogs_use_header
-
         Gtk.Dialog.__init__(self, _(f'Remove {title}'), parent, 0,
                             (Gtk.STOCK_CANCEL, Gtk.ResponseType.CANCEL,
                              Gtk.STOCK_REMOVE, Gtk.ResponseType.OK),
@@ -296,9 +289,6 @@ class EditDialog(Gtk.Dialog):
     ppa_name = False
 
     def __init__(self, parent, source):
-
-        settings = Gtk.Settings.get_default()
-        header = settings.props.gtk_dialogs_use_header
         self.source = source
         # Ensure the source is fully up to date.
         self.source.load_from_file()

--- a/repoman/dialog.py
+++ b/repoman/dialog.py
@@ -65,7 +65,8 @@ class ErrorDialog(Gtk.Dialog):
 
         dialog_label = Gtk.Label()
         dialog_label.set_markup(f'<b>{message_title}</b>')
-        dialog_message = Gtk.Label(message_text)
+        dialog_message = Gtk.Label()
+        dialog_message.set_markup(message_text)
         content_grid.attach(dialog_label, 1, 0, 1, 1)
         content_grid.attach(dialog_message, 1, 1, 1, 1)
 

--- a/repoman/dialog.py
+++ b/repoman/dialog.py
@@ -44,6 +44,7 @@ class ErrorDialog(Gtk.Dialog):
                  
         super().__init__(use_header_bar=header, modal=1)
         self.set_deletable(False)
+        self.set_transient_for(parent)
 
         self.log = logging.getLogger("repoman.ErrorDialog")
         

--- a/repoman/list.py
+++ b/repoman/list.py
@@ -208,7 +208,32 @@ class List(Gtk.Box):
         self.ppa_liststore.clear()
 
         self.sources = {}
-        self.sources = repo.get_all_sources()
+        self.sources, errors = repo.get_all_sources()
+        
+        # Display an error dialog for invalid sources
+        if errors:
+            err_string = 'The following source files had errors and were omitted:\n'
+            for file in errors:
+                err_string += f'    {file}\n'
+            err_string += '\nRun '
+            err_string += (
+                '<span '
+                'font-family="monospace" '
+                'background="#333333" '
+                'foreground="white" '
+                '> apt-manage -b </span> '
+            )
+            err_string += 'for more information'
+            err_dialog = ErrorDialog(
+                self.parent.parent,
+                'Source File Errors',
+                'dialog-warning',
+                'Some sources contained errors',
+                err_string
+            )
+            err_dialog.run()
+            err_dialog.destroy()
+
         self.log.debug('Sources found:\n%s', self.sources)
         for i in self.sources:
             source = self.sources[i]

--- a/repoman/list.py
+++ b/repoman/list.py
@@ -213,27 +213,10 @@ class List(Gtk.Box):
         
         # Display an error dialog for invalid sources
         if errors:
-            err_string = 'The following source files had errors and were omitted:\n'
+            err_string = 'The following source files have errors:\n\n'
             for file in errors:
-                err_string += f'    {file}\n'
-            err_string += '\nRun '
-            err_string += (
-                '<span '
-                'font-family="monospace" '
-                'background="#333333" '
-                'foreground="white" '
-                '> apt-manage -b </span> '
-            )
-            err_string += 'for more information'
-            err_dialog = ErrorDialog(
-                self.parent.parent,
-                'Source File Errors',
-                'dialog-warning',
-                'Some sources contained errors',
-                err_string
-            )
-            err_dialog.run()
-            err_dialog.destroy()
+                err_string += f'{file}\n'
+            self.log.warning(err_string)
 
         self.log.debug('Sources found:\n%s', self.sources)
         for i in self.sources:

--- a/repoman/list.py
+++ b/repoman/list.py
@@ -211,7 +211,7 @@ class List(Gtk.Box):
         self.sources = {}
         self.sources, errors = repo.get_all_sources()
         
-        # Display an error dialog for invalid sources
+        # Print a warning to console about source file errors.
         if errors:
             err_string = 'The following source files have errors:\n\n'
             for file in errors:

--- a/repoman/main.py
+++ b/repoman/main.py
@@ -39,6 +39,12 @@ class Application(Gtk.Application):
         self.win.connect("delete-event", self.application_quit)
         self.win.show_all()
 
+        # If there are errors in source files, display the dialog to inform 
+        # the user.
+        if self.win.err_dialog:
+            self.win.err_dialog.run()
+            self.win.err_dialog.destroy()
+
         Gtk.main()
     
     def application_quit(self, widget, data=None):

--- a/repoman/main.py
+++ b/repoman/main.py
@@ -35,15 +35,7 @@ class Application(Gtk.Application):
     def do_activate(self):
 
         self.win = Window()
-        self.win.set_default_size(700, 400)
         self.win.connect("delete-event", self.application_quit)
-        self.win.show_all()
-
-        # If there are errors in source files, display the dialog to inform 
-        # the user.
-        if self.win.err_dialog:
-            self.win.err_dialog.run()
-            self.win.err_dialog.destroy()
 
         Gtk.main()
     

--- a/repoman/repo.py
+++ b/repoman/repo.py
@@ -131,7 +131,10 @@ def get_all_sources(get_system=False):
     except FileNotFoundError:
         sources_list_file = None
     
-    sources_list = repolib.get_all_sources(get_system=get_system)
+    sources_list, errors = repolib.get_all_sources(
+        get_system=get_system,
+        get_exceptions=True
+    )
 
     for source in sources_list:
         sources[source.ident] = source
@@ -139,7 +142,7 @@ def get_all_sources(get_system=False):
     if sources_list_file:
         sources['sources.list'] = {}
     
-    return sources
+    return sources, errors
 
 def get_os_codename():
     """ Returns the current OS codename."""

--- a/repoman/stack.py
+++ b/repoman/stack.py
@@ -44,6 +44,9 @@ class Stack(Gtk.Box):
             self.system_repo = repo.get_system_repo()
         except:
             self.system_repo = None
+        self.sources = {}
+        self.errors = {}
+        self.sources, self.errors = repo.get_all_sources()
 
         self.stack = Gtk.Stack()
         self.stack.set_transition_type(Gtk.StackTransitionType.SLIDE_LEFT_RIGHT)

--- a/repoman/window.py
+++ b/repoman/window.py
@@ -22,6 +22,8 @@
 import gi
 gi.require_version('Gtk', '3.0')
 from gi.repository import Gtk, Gdk, GLib
+
+from .dialog import ErrorDialog
 from .headerbar import Headerbar
 from .stack import Stack
 
@@ -29,6 +31,10 @@ class Window(Gtk.Window):
 
     def __init__(self):
         Gtk.Window.__init__(self)
+
+        self.set_position(Gtk.WindowPosition.CENTER)
+
+        self.err_dialog = None
 
         self.hbar = Headerbar(self)
         self.set_titlebar(self.hbar)
@@ -47,4 +53,29 @@ class Window(Gtk.Window):
         self.context = Gtk.StyleContext()
         self.context.add_provider_for_screen(self.screen, self.css_provider,
           Gtk.STYLE_PROVIDER_PRIORITY_USER)
-
+        
+        # Set up an error dialog to inform the user about source errors.
+        if self.stack.errors:
+            self.get_repos_error_dialog()
+    
+    def get_repos_error_dialog(self):
+        err_string = 'The following source files had errors and were omitted:\n'
+        for file in self.stack.errors:
+            err_string += f'    {file}\n'
+        err_string += '\nRun '
+        err_string += (
+            '<span '
+            'font-family="monospace" '
+            'background="#333333" '
+            'foreground="white" '
+            '> apt-manage -b </span> '
+        )
+        err_string += 'for more information.'
+        self.err_dialog = ErrorDialog(
+            self,
+            'Source File Errors',
+            'dialog-warning',
+            'Some sources contained errors',
+            err_string
+        )
+        self.err_dialog.set_position(Gtk.WindowPosition.CENTER_ON_PARENT)

--- a/repoman/window.py
+++ b/repoman/window.py
@@ -33,6 +33,7 @@ class Window(Gtk.Window):
         Gtk.Window.__init__(self)
 
         self.set_position(Gtk.WindowPosition.CENTER)
+        self.set_default_size(700, 400)
 
         self.err_dialog = None
 
@@ -54,9 +55,13 @@ class Window(Gtk.Window):
         self.context.add_provider_for_screen(self.screen, self.css_provider,
           Gtk.STYLE_PROVIDER_PRIORITY_USER)
         
-        # Set up an error dialog to inform the user about source errors.
+        self.show_all()
+        
+        # Show an error dialog to inform the user about source errors.
         if self.stack.errors:
             self.get_repos_error_dialog()
+            self.err_dialog.run()
+            self.err_dialog.destroy()
     
     def get_repos_error_dialog(self):
         err_string = 'The following source files had errors and were omitted:\n'


### PR DESCRIPTION
Now that Repoman is no logner crashing when there are invalid sources, it would be very helpful to inform the user when their sources have errors. This PR adds an error dialog when repolib detects sources files with invalid entries, listing the filenames of the bad files and instructions for getting more information about the errors.

![image](https://user-images.githubusercontent.com/5883565/97221415-745f5180-1792-11eb-9f9d-501311b244d9.png)

This doesn't prevent valid sources from loading and being modified in the GUI. 

Requires pop-os/repolib#26