### PR TITLE
Disable "Reset Mirrors" button when the mirrors are set to defaults

### DIFF
--- a/repoman/list.py
+++ b/repoman/list.py
@@ -25,7 +25,6 @@ import logging
 import gi
 gi.require_version('Gtk', '3.0')
 from gi.repository import Gtk, Gio
-from softwareproperties.SoftwareProperties import SoftwareProperties
 
 from . import repo
 from .dialog import AddDialog, DeleteDialog, EditDialog, ErrorDialog
@@ -39,7 +38,6 @@ class List(Gtk.Box):
     listiter_count = 0
 
     def __init__(self, parent):
-        self.sp = SoftwareProperties()
         Gtk.Box.__init__(self, False, 0)
         self.parent = parent
 

--- a/repoman/settings.py
+++ b/repoman/settings.py
@@ -110,19 +110,19 @@ class Settings(Gtk.Box):
 
         if self.system_repo:
             if self.system_repo.default_mirror:
-                reset_mirrors_button = Gtk.Button()
-                reset_mirrors_button.set_label(_('Reset Mirrors to Defaults'))
-                reset_mirrors_button.set_halign(Gtk.Align.END)
-                reset_mirrors_button.set_margin_top(6)
+                self.reset_mirrors_button = Gtk.Button()
+                self.reset_mirrors_button.set_label(_('Reset Mirrors to Defaults'))
+                self.reset_mirrors_button.set_halign(Gtk.Align.END)
+                self.reset_mirrors_button.set_margin_top(6)
                 Gtk.StyleContext.add_class(
-                    reset_mirrors_button.get_style_context(),
+                    self.reset_mirrors_button.get_style_context(),
                     'destructive-action'
                 )
-                reset_mirrors_button.connect(
+                self.reset_mirrors_button.connect(
                     'clicked',
                     self.on_reset_mirror_button_clicked
                 )
-                settings_grid.attach(reset_mirrors_button, 0, 3, 1, 1)
+                settings_grid.attach(self.reset_mirrors_button, 0, 3, 1, 1)
 
         self.checks_grid = Gtk.VBox()
         self.checks_grid.set_margin_left(12)
@@ -263,6 +263,12 @@ class Settings(Gtk.Box):
                 mirror_entry.set_icon_from_icon_name(sec_pos, '')
             self.mirror_box.pack_start(mirror_entry, True, True, 0)
             mirror_entry.show()
+        
+        if self.system_repo.default_mirror:
+            if [self.system_repo.default_mirror] == self.system_repo.uris:
+                self.reset_mirrors_button.set_sensitive(False)
+            else:
+                self.reset_mirrors_button.set_sensitive(True)
 
     def do_entry_add(self, entry, *args, **kwargs):
         """ :icon-release: signal handler for the new_mirror_entry."""


### PR DESCRIPTION
This checks if the current mirrors are the same as the system-defined default mirror and, if so, disables the reset button. This provides better UX because the button wouldn't have any effect anyway. 

Any change which brings the mirrors to the same as the default will disable the button as well.

Fixes #76 