### PR TITLE
fix: display more error messages

### DIFF
--- a/data/style.css
+++ b/data/style.css
@@ -59,22 +59,27 @@ in a message dialog wonky. It doesn't happen in other python projects, but I
 can't figure out what's causing the problem. */
 
 messagedialog > decoration {
-	margin: 0px;
-  }
-  
-  messagedialog .dialog-vbox {
-	padding: 0px;
-	margin: -6px;
-  }
-  messagedialog > .dialog-vbox > * {
-	padding: 0 12px;
-  }
-  
-  messagedialog box.titlebar {
-	padding: 0px;
-  }
-  
-  .dialog-action-area {
-	margin: 0 -12px;
-	margin-top: 6px;
-  }
+  margin: 0px;
+}
+
+messagedialog .dialog-vbox {
+  padding: 0px;
+  margin: -6px;
+}
+
+messagedialog > .dialog-vbox > box:not(.dialog-action-box) {
+  padding: 0 12px;
+}
+
+messagedialog expander {
+  margin: 0 24px;
+}
+
+messagedialog box.titlebar {
+  padding: 0px;
+}
+
+.dialog-action-area {
+  margin: 0;
+  margin-top: 0;
+}

--- a/data/style.css
+++ b/data/style.css
@@ -64,7 +64,7 @@ messagedialog > decoration {
 
 messagedialog .dialog-vbox {
   padding: 0px;
-  margin: -6px;
+  margin: 0px;
 }
 
 messagedialog > .dialog-vbox > box:not(.dialog-action-box) {

--- a/data/style.css
+++ b/data/style.css
@@ -53,3 +53,28 @@ separator {
 .list_window {
   margin-top: 10px;
 }
+
+/* This is required because of some bug with GTK that makes the buttons
+in a message dialog wonky. It doesn't happen in other python projects, but I 
+can't figure out what's causing the problem. */
+
+messagedialog > decoration {
+	margin: 0px;
+  }
+  
+  messagedialog .dialog-vbox {
+	padding: 0px;
+	margin: -6px;
+  }
+  messagedialog > .dialog-vbox > * {
+	padding: 0 12px;
+  }
+  
+  messagedialog box.titlebar {
+	padding: 0px;
+  }
+  
+  .dialog-action-area {
+	margin: 0 -12px;
+	margin-top: 6px;
+  }

--- a/repoman/dialog.py
+++ b/repoman/dialog.py
@@ -162,6 +162,17 @@ class AddDialog(Gtk.Dialog):
         self.title_spinner.set_visible_child_name('spinner')
         self.set_sensitive(False)
 
+    def show_error(self, exc):
+        self.log.error('Could not add source: %s', self.repo_entry.get_text())
+        err_dialog = repo.get_error_messagedialog(
+            self,
+            'Could not add source',
+            exc,
+            f'{self.repo_entry.get_text()} could not be added'
+        )
+        err_dialog.run()
+        err_dialog.destroy()
+
 class DeleteDialog(Gtk.Dialog):
 
     ppa_name = False

--- a/repoman/list.py
+++ b/repoman/list.py
@@ -152,7 +152,7 @@ class List(Gtk.Box):
             success = repo.delete_repo(repo_name)
         else:
             dialog.destroy()
-            success = True
+            success = False
         
         if not success:
             error_dialog = Gtk.MessageDialog(

--- a/repoman/list.py
+++ b/repoman/list.py
@@ -230,6 +230,9 @@ class List(Gtk.Box):
             repo.add_source(url, dialog)
         else:
             dialog.destroy()
+        
+        # Ensure this is set sensitive again
+        self.add_button.set_sensitive(True)
 
     def generate_entries(self, *args, **kwargs):
         self.log.debug('Generating list of repos')

--- a/repoman/repo.py
+++ b/repoman/repo.py
@@ -260,3 +260,4 @@ def delete_repo(repo):
     privileged_object = bus.get_object('org.pop_os.repolib', '/Repo')
     privileged_object.delete_source(repo)
     privileged_object.exit()
+    return True

--- a/repoman/repo.py
+++ b/repoman/repo.py
@@ -201,6 +201,9 @@ def get_error_messagedialog(parent, text, exc, prefix):
     traceback_label.set_line_wrap(True)
     expander.add(traceback_label)
     content_area.add(expander)
+
+    action_area = dialog.get_action_area()
+    action_area.set_layout(Gtk.ButtonBoxStyle.EXPAND)
     dialog.show_all()
 
     return dialog

--- a/repoman/repo.py
+++ b/repoman/repo.py
@@ -193,7 +193,8 @@ def get_error_messagedialog(parent, text, exc, prefix):
     )
 
     traceback_text = ' '.join(traceback.format_tb(exc.__traceback__))
-    dialog.format_secondary_markup(f'{prefix}:\n{str(exc)}')
+    secondary_text = GLib.markup_escape_text(str(exc))
+    dialog.format_secondary_markup(f'{prefix}:\n{secondary_text}')
     content_area = dialog.get_content_area()
     
     expander = Gtk.Expander.new('Error details:')

--- a/repoman/repo.py
+++ b/repoman/repo.py
@@ -209,5 +209,6 @@ def delete_repo(repo):
     """
     bus = dbus.SystemBus()
     privileged_object = bus.get_object('org.pop_os.repolib', '/Repo')
-    privileged_object.delete_source(repo)
+    success = privileged_object.delete_source(repo)
     privileged_object.exit()
+    return success

--- a/repoman/settings.py
+++ b/repoman/settings.py
@@ -277,8 +277,21 @@ class Settings(Gtk.Box):
             uris = self.system_repo.uris
             if not new_uri in uris:
                 uris.append(new_uri)
-            self.system_repo.uris = uris
-            self.system_repo.save_to_disk()
+            try:
+                self.system_repo.uris = uris
+                self.system_repo.save_to_disk()
+            except Exception as err:
+                self.log.error(
+                    'Could not add mirror %s: %s', new_uri, str(err)
+                )
+                err_dialog = repo.get_error_messagedialog(
+                    self.parent.parent,
+                    f'Could not add URI',
+                    err,
+                    f'{new_uri} could not be added to the system mirrors'
+                )
+                err_dialog.run()
+                err_dialog.destroy()
     
     def do_new_entry_changed(self, entry):
         """ :changed: signal handler for the new-mirror entry."""
@@ -319,8 +332,21 @@ class Settings(Gtk.Box):
             if new_entry and action_edit:
                 uris.append(entry.get_text())
 
-            self.system_repo.uris = uris
-            self.system_repo.save_to_disk()
+            try:
+                self.system_repo.uris = uris
+                self.system_repo.save_to_disk()
+            except Exception as err:
+                self.log.error(
+                    'Could not remove mirror %s: %s', entry.uri, str(err)
+                )
+                err_dialog = repo.get_error_messagedialog(
+                    self.parent.parent,
+                    f'Could not remove mirror',
+                    err,
+                    f'The mirror {entry.uri} could not be removed'
+                )
+                err_dialog.run()
+                err_dialog.destroy()
 
 
     def get_new_switch(self, component, description=None):
@@ -440,7 +466,20 @@ class Settings(Gtk.Box):
         self.system_repo['Types'] = 'deb'
         if state:
             self.system_repo['Types'] = 'deb deb-src'
-        self.system_repo.save_to_disk()
+        try:
+            self.system_repo.save_to_disk()
+        except Exception as err:
+            self.log.error(
+                    'Could not set source code: %s', str(err)
+            )
+            err_dialog = repo.get_error_messagedialog(
+                self.parent.parent,
+                f'Could not set Source Code',
+                err,
+                'The system source code status could not be changed'
+            )
+            err_dialog.run()
+            err_dialog.destroy()
 
     def on_proposed_check_toggled(self, switch, state):
         self.system_repo.set_suite_enabled(
@@ -457,5 +496,18 @@ class Settings(Gtk.Box):
 
     def on_reset_mirror_button_clicked(self, button):
         self.log.warning('Resetting mirrors to default values.')
-        self.system_repo.set_default_mirror()
-        self.system_repo.save_to_disk()
+        try:
+            self.system_repo.set_default_mirror()
+            self.system_repo.save_to_disk()
+        except Exception as err:
+            self.log.error(
+                'Could not reset mirrors'
+            )
+            err_dialog = repo.get_error_messagedialog(
+                self.parent.parent,
+                f'Could not reset the system mirrors',
+                err,
+                'The system mirrors could not be reset'
+            )
+            err_dialog.run()
+            err_dialog.destroy()


### PR DESCRIPTION
Taking advantage of pop-os/repolib#30, this causes repoman to display error messages if it receives an exception from repolib. The error dialog that opens contains a description of the problem and the exception text, as well as the traceback of the exception (hidden by default behind an expander so as to avoid cluttering the UI). This should greatly improve the user experience in the event of a typo in a repository or PPA.