### PR TITLE
Rendering fixes

### DIFF
--- a/repoman/list.py
+++ b/repoman/list.py
@@ -254,7 +254,7 @@ class List(Gtk.Box):
         for i in self.sources:
             source = self.sources[i]
             try:
-                if source.enabled:
+                if source.enabled.get_bool():
                     self.log.debug('Source: %s, URIs: %s', source.name, source.uris[0])
                     self.ppa_liststore.insert_with_valuesv(
                         -1,
@@ -268,7 +268,7 @@ class List(Gtk.Box):
         for i in self.sources:
             source = self.sources[i]
             try:
-                if not source.enabled: 
+                if not source.enabled.get_bool(): 
                     self.ppa_liststore.insert_with_valuesv(
                         -1,
                         [0, 1, 2],

--- a/repoman/list.py
+++ b/repoman/list.py
@@ -281,7 +281,7 @@ class List(Gtk.Box):
             self.ppa_liststore.insert_with_valuesv(
                 -1,
                 [0, 1, 2],
-                ['sources.list', '<i>Legacy System Sources</i>', 'x-repoman-legacy-sources']
+                ['<i>sources.list</i>', '<i>Legacy System Sources</i>', 'x-repoman-legacy-sources']
             )
             
         self.add_button.set_sensitive(True)


### PR DESCRIPTION
Fixes the rendering of sources on the "Extra Sources" tab

* Ensures that disabled sources are rendered without a bold name (helps to visually show that a source is disabled)
* Ensures that the legacy source (if present) is rendered in italics (helps to separate the legacy source from disabled sources)

For testing:

* Ensure that there is a `/etc/apt/sources.list` file present and non-empty. It should show up in Repoman as italics (similar to the description listing). 
* Disable a source listed on the main "Extra sources" tab. Ensure that this source is rendered with a non-bolded name. 