### PR TITLE
Repolib 2

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -14,7 +14,7 @@ Package: repoman
 Architecture: all
 Depends: ${python3:Depends}, ${misc:Depends},
          gir1.2-gtk-3.0,
-         python3-repolib
+         python3-repolib (>= 2.0)
 Description: Repoman
  Hey man, let's go do crimes. Yeah, let's install software and not pay.
 

--- a/repoman/dialog.py
+++ b/repoman/dialog.py
@@ -149,11 +149,11 @@ class AddDialog(Gtk.Dialog):
         else:
             entry_valid = repo.validate(entry_text)
         
-        entry_isppa = entry_text.startswith('ppa')
+        entry_isshortcut = entry_text in ['ppa', 'popdev']
         entry_isdeb = entry_text.startswith('deb')
 
         # If we're dealing with a plain URL, it can't have spaces
-        if not entry_isppa and not entry_isdeb:
+        if not entry_isshortcut and not entry_isdeb:
             uri = entry_text.split()
             if len(uri) != 1:
                 entry_valid = False
@@ -317,7 +317,7 @@ class EditDialog(Gtk.Dialog):
     def __init__(self, parent, source):
         self.source = source
         # Ensure the source is fully up to date.
-        self.source.load_from_file()
+        self.source.file.load()
 
         Gtk.Dialog.__init__(self, _("Modify Source"), parent, 0,
                             (Gtk.STOCK_CANCEL, Gtk.ResponseType.CANCEL,
@@ -366,12 +366,12 @@ class EditDialog(Gtk.Dialog):
         self.name_entry.set_text(self.source['X-Repolib-Name'])
         self.name_entry.set_activates_default(False)
         self.name_entry.set_width_chars(40)
-        self.name_entry.connect('changed', self.on_entry_changed, 'X-Repolib-Name')
+        # self.name_entry.connect('changed', self.on_entry_changed, 'X-Repolib-Name')
         content_grid.attach(self.name_entry, 1, 0, 1, 1)
 
         self.source_switch = Gtk.Switch()
         self.source_switch.set_halign(Gtk.Align.START)
-        self.source_switch.set_active(self.source.source_code_enabled)
+        self.source_switch.set_active(self.source.sourcecode_enabled)
         self.source_switch.connect('state-set', self.on_source_switch_changed)
         content_grid.attach(self.source_switch, 1, 1, 1, 1)
 
@@ -380,21 +380,21 @@ class EditDialog(Gtk.Dialog):
         self.uri_entry.set_text(self.source['URIs'])
         self.uri_entry.set_activates_default(False)
         self.uri_entry.set_width_chars(40)
-        self.uri_entry.connect('changed', self.on_entry_changed, 'URIs')
+        # self.uri_entry.connect('changed', self.on_entry_changed, 'URIs')
         content_grid.attach(self.uri_entry, 1, 2, 1, 1)
 
         self.version_entry = Gtk.Entry()
         self.version_entry.set_placeholder_text(repo.get_os_codename())
         self.version_entry.set_text(self.source['Suites'])
         self.version_entry.set_activates_default(False)
-        self.version_entry.connect('changed', self.on_entry_changed, 'Suites')
+        # self.version_entry.connect('changed', self.on_entry_changed, 'Suites')
         content_grid.attach(self.version_entry, 1, 3, 1, 1)
 
         self.component_entry = Gtk.Entry()
         self.component_entry.set_placeholder_text("main")
         self.component_entry.set_text(self.source['Components'])
         self.component_entry.set_activates_default(False)
-        self.component_entry.connect('changed', self.on_entry_changed, 'Components')
+        # self.component_entry.connect('changed', self.on_entry_changed, 'Components')
         content_grid.attach(self.component_entry, 1, 4, 1, 1)
 
         self.enabled_switch = Gtk.Switch()
@@ -443,7 +443,7 @@ class EditDialog(Gtk.Dialog):
     
     def on_source_switch_changed(self, switch, state):
         """ switch::state-set handler for source code switch. """
-        self.source.set_source_enabled(state)
+        self.source.sourcecode_enabled = state
     
     def on_enabled_switch_changed(self, switch, state):
         """ switch::state-set handler for enabled switch. """

--- a/repoman/list.py
+++ b/repoman/list.py
@@ -274,8 +274,8 @@ class List(Gtk.Box):
 
         # self.log.debug('Sources found:\n%s', repo.sources)
         for i in repo.sources:
-            # if i == 'system':
-            #     continue
+            if i == 'system':
+                continue
             source = repo.sources[i]
             try:
                 if source.enabled.get_bool():

--- a/repoman/list.py
+++ b/repoman/list.py
@@ -200,10 +200,10 @@ class List(Gtk.Box):
         response = dialog.run()
 
         if response != Gtk.ResponseType.OK:
-            dialog.source.load_from_file()
+            dialog.source.file.load()
         else:
             try:
-                dialog.source.save_to_disk()
+                dialog.source.file.save()
             except Exception as err:
                 self.log.error(
                     'Could not edit mirror %s: %s', source.ident, str(err)

--- a/repoman/list.py
+++ b/repoman/list.py
@@ -240,18 +240,20 @@ class List(Gtk.Box):
         self.log.debug('Generating list of repos')
         self.ppa_liststore.clear()
 
-        self.sources = {}
-        self.sources, errors = repo.get_all_sources()
+        self.sources = repo.sources
+        repo.load_all_sources()
         
         # Print a warning to console about source file errors.
-        if errors:
+        if repo.errors:
             err_string = 'The following source files have errors:\n\n'
-            for file in errors:
+            for file in repo.errors:
                 err_string += f'{file}\n'
             self.log.warning(err_string)
 
         self.log.debug('Sources found:\n%s', self.sources)
         for i in self.sources:
+            # if i == 'system':
+            #     continue
             source = self.sources[i]
             try:
                 if source.enabled.get_bool():
@@ -276,13 +278,6 @@ class List(Gtk.Box):
                     )
             except AttributeError:
                 pass
-        
-        if 'sources.list' in self.sources:
-            self.ppa_liststore.insert_with_valuesv(
-                -1,
-                [0, 1, 2],
-                ['<i>sources.list</i>', '<i>Legacy System Sources</i>', 'x-repoman-legacy-sources']
-            )
             
         self.add_button.set_sensitive(True)
 

--- a/repoman/repo.py
+++ b/repoman/repo.py
@@ -30,7 +30,8 @@ import gi
 from gi.repository import GLib, Gtk
 import repolib
 
-repolib.set_logging_level(2)
+## Uncomment for debugging
+# repolib.set_logging_level(2)
 
 repolib.system.load_all_sources()
 sources = repolib.util.sources

--- a/repoman/repo.py
+++ b/repoman/repo.py
@@ -19,6 +19,7 @@
 '''
 
 import logging
+from pathlib import Path
 import subprocess
 import threading
 import traceback
@@ -28,6 +29,11 @@ import dbus
 import gi
 from gi.repository import GLib, Gtk
 import repolib
+
+repolib.system.load_all_sources()
+sources = repolib.util.sources
+errors = repolib.util.errors
+load_all_sources = repolib.system.load_all_sources
 
 log = logging.getLogger("repoman.Repo")
 log.debug('Logging established')
@@ -60,7 +66,7 @@ def edit_system_legacy_sources_list():
 
 def get_system_repo():
     """Get a repo for the system sources. """
-    repo = repolib.SystemSource()
+    repo = repolib.util.sources['system']
     return repo
 
 def url_validator(url):
@@ -125,19 +131,17 @@ def get_all_sources(get_system=False):
         The above described dict.
     """
     sources = {}
-    sources_dir = repolib.util.get_sources_dir()
+    sources_dir = Path(repolib.SOURCES_DIR)
     try:
         sources_list_file = sources_dir.parent / 'sources.list'
     except FileNotFoundError:
         sources_list_file = None
     
-    sources_list, errors = repolib.get_all_sources(
-        get_system=get_system,
-        get_exceptions=True
-    )
+    sources_list = repolib.util.sources
+    errors = repolib.util.errors
 
     for source in sources_list:
-        sources[source.ident] = source
+        sources[source] = sources_list[source]
     
     if sources_list_file:
         sources['sources.list'] = {}


### PR DESCRIPTION
Updates Repoman to use RepoLib 2. Ensures that the package will not be upgraded without the requisite repolib version via `debian/control`.

This should probably be merged prior to merging the Repolib `repolib2` PR as merging that one first would cause Repoman breakage in existing installs. Both PRs use the same branch name, so they can be tested simultaneously.