### PR TITLE
fix(window): change repolib command for new version

### DIFF
--- a/repoman/window.py
+++ b/repoman/window.py
@@ -73,7 +73,7 @@ class Window(Gtk.Window):
             'font-family="monospace" '
             'background="#333333" '
             'foreground="white" '
-            '> apt-manage -b </span> '
+            '> apt-manage list -va </span> '
         )
         err_string += 'for more information.'
         self.err_dialog = ErrorDialog(


### PR DESCRIPTION
The previous `apt-manage -b` command no longer functions the same in repolib v2. This updates the helper text of this dialog with the correct command to get information about malformed files.