### PR TITLE
fix(packaging): add gir1.2-flatpak-1.0 to package recommends

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -7,6 +7,7 @@ Build-Depends: debhelper (>= 10),
                python3-all,
                gir1.2-gtk-3.0,
                libflatpak-dev,
+               gir1.2-flatpak-1.0
 Standards-Version: 3.9.3
 X-Python3-Version: >= 3.4
 
@@ -15,6 +16,7 @@ Architecture: all
 Depends: ${python3:Depends}, ${misc:Depends},
          gir1.2-gtk-3.0,
          python3-repolib (>= 2.0)
+Recommends: gir1.2-flatpak-1.0
 Description: Repoman
  Hey man, let's go do crimes. Yeah, let's install software and not pay.
 


### PR DESCRIPTION
Adds the `gir1.2-flatpak-1.0` package to the Repoman recommends. This should help ensure the package is installed and allow Repoman to display the Flatpak tab. Note that it may still be possible to remove the package and cause the Flatpak tab not to appear. As Repoman is designed to function either with or without that tab, `Recommends` is the correct place to add this dependency, as the program does function fine (without Flatpak functionality) without it.

Fixes #110 