### PR TITLE
fix: remove gtk_widget_get_can_default warning message

### DIFF
--- a/repoman/dialog.py
+++ b/repoman/dialog.py
@@ -138,6 +138,7 @@ class AddDialog(Gtk.Dialog):
 
         Gtk.StyleContext.add_class(self.add_button.get_style_context(),
                                    "suggested-action")
+        self.add_button.set_can_default(True)
         self.add_button.grab_default()
 
         self.show_all()
@@ -1162,6 +1163,7 @@ class InstallDialog(Gtk.Dialog):
 
         self.install_button = self.get_widget_for_response(Gtk.ResponseType.OK)
         self.install_button.set_sensitive(False)
+        self.install_button.set_can_default(True)
         self.install_button.grab_default()
         self.install_button.set_label(_('Install'))
         Gtk.StyleContext.add_class(self.install_button.get_style_context(),

--- a/repoman/settings.py
+++ b/repoman/settings.py
@@ -157,7 +157,6 @@ class Settings(Gtk.Box):
         self.create_switches()
         if self.system_repo:
             self.on_config_changed(None, None, None, None)
-            developer_options.grab_default()
             developer_options.grab_focus()
         else:
             self.switches_sensitive = False


### PR DESCRIPTION
Fixes #91 

Removes the default widget set on the developer options. I'm not sure why we thought that was an important widget on which to set the default anyway, but at least now we won't have to worry about it. 

Testing:
Check for no regressions (other than the "Developer Options" expander no longer being the default widget). 
Check that the problem error message has disappeared from console output:

```
gtk_widget_grab_default: assertion 'gtk_widget_get_can_default (widget)'
```