### PR TITLE
add tooltip for install_button

### DIFF
--- a/repoman/flatpak.py
+++ b/repoman/flatpak.py
@@ -127,6 +127,7 @@ class Flatpak(Gtk.Box):
         self.install_button.set_icon_name('system-software-install-symbolic')
         Gtk.StyleContext.add_class(self.install_button.get_style_context(),
                                    "image-button")
+        self.install_button.set_tooltip_text(_("Install a local Flatpak file"))
         self.install_button.connect('clicked', self.show_install_dialog)
 
         # info button

--- a/repoman/flatpak.py
+++ b/repoman/flatpak.py
@@ -127,7 +127,7 @@ class Flatpak(Gtk.Box):
         self.install_button.set_icon_name('system-software-install-symbolic')
         Gtk.StyleContext.add_class(self.install_button.get_style_context(),
                                    "image-button")
-        self.install_button.set_tooltip_text(_("Install a local Flatpak file"))
+        self.install_button.set_tooltip_text(_("Install Local Flatpak File"))
         self.install_button.connect('clicked', self.show_install_dialog)
 
         # info button


### PR DESCRIPTION
On the Flatpak Sources view, the buttons in the user-action toolbar use tooltips to clarify their effect.

Currently, the button to install a Flatpak from the local filesystem does not have a tooltip. 

The proposed change adds a tooltip to this button.



https://github.com/pop-os/repoman/assets/10716475/234da50e-6d33-44b2-8de0-20bc37aea3fe

