### PR TITLE
Allow repoman to be displayed in app library

### DIFF
--- a/data/repoman.desktop
+++ b/data/repoman.desktop
@@ -9,4 +9,3 @@ Terminal=false
 Type=Application
 X-GNOME-Gettext-Domain=repoman
 Keywords=Python;
-NoDisplay=true


### PR DESCRIPTION
Fixes https://github.com/pop-os/repoman/issues/118