### PR TITLE
fix (packaging): Add gir1.2-notify-0.7 dependency

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -15,6 +15,7 @@ Package: repoman
 Architecture: all
 Depends: ${python3:Depends}, ${misc:Depends},
          gir1.2-gtk-3.0,
+         gir1.2-notify-0.7,
          python3-repolib (>= 2.0)
 Recommends: gir1.2-flatpak-1.0
 Description: Repoman, A Software Sources Manager


### PR DESCRIPTION
Closes https://github.com/pop-os/cosmic-epoch/issues/692 and closes https://github.com/pop-os/repoman/issues/119.

We likely didn't notice this was missing because it's a dependency of `system76-driver`, which is installed on the machines we typically test with. But on third-party hardware where the driver's not installed, this package may not be present, and without it, repoman fails to launch.