### PR TITLE
Don't traceback when no DISPLAY or WAYLAND_DISPLAY

### DIFF
--- a/repoman/main.py
+++ b/repoman/main.py
@@ -19,6 +19,7 @@
     along with Repoman.  If not, see <http://www.gnu.org/licenses/>.
 '''
 
+import sys
 import gi
 gi.require_version('Gtk', '3.0')
 from gi.repository import Gtk, Gdk
@@ -28,6 +29,9 @@ try:
 except ImportError:
     JournalHandler = False
 
+if not Gtk.Settings.get_default():
+    print("Error: no DISPLAY or WAYLAND_DISPLAY environment variable specified")
+    sys.exit(1)
 from .window import Window
 
 class Application(Gtk.Application):


### PR DESCRIPTION
I accidentally tried to run repoman over SSH and got this traceback

    Traceback (most recent call last):
      File "<frozen runpy>", line 198, in _run_module_as_main
      File "<frozen runpy>", line 88, in _run_code
      File "/home/jkadlcik/git/repoman/repoman/main.py", line 31, in <module>
        from .window import Window
      File "/home/jkadlcik/git/repoman/repoman/window.py", line 26, in <module>
        from .dialog import ErrorDialog
      File "/home/jkadlcik/git/repoman/repoman/dialog.py", line 40, in <module>
        header = settings.props.gtk_dialogs_use_header
                 ^^^^^^^^^^^^^^
    AttributeError: 'NoneType' object has no attribute 'props'